### PR TITLE
Log abnormal distributor configuration on start up

### DIFF
--- a/codebase/src/java/disco/org/openlvc/distributor/Distributor.java
+++ b/codebase/src/java/disco/org/openlvc/distributor/Distributor.java
@@ -76,6 +76,9 @@ public class Distributor
 	 */
 	public void up()
 	{
+		if( links.size() == 0 )
+			logger.warn( "No links have been configured" );
+
 		// do we even have anything to bring up?
 		if( areAnyLinksDown() == false )
 			return;

--- a/codebase/src/java/disco/org/openlvc/distributor/configuration/Configuration.java
+++ b/codebase/src/java/disco/org/openlvc/distributor/configuration/Configuration.java
@@ -191,17 +191,21 @@ public class Configuration
 		File configurationFile = new File( this.configFile );
 		if( configurationFile.exists() )
 		{
-    		// configuration file exists, load the properties into it
-    		try
-    		{
-    			properties.load( configurationFile.toURI().toURL().openStream() );
-    		}
-    		catch( Exception e )
-    		{
-    			throw new RuntimeException( "Problem parsing config file: "+e.getMessage(), e );
-    		}
+			// configuration file exists, load the properties into it
+			try
+			{
+				properties.load( configurationFile.toURI().toURL().openStream() );
+			}
+			catch( Exception e )
+			{
+				throw new RuntimeException( "Problem parsing config file: "+e.getMessage(), e );
+			}
 		}
-		
+		else
+		{
+			getApplicationLogger().error( "Configuration file does not exist at "+configurationFile.getPath() );
+		}
+
 		//
 		// pull the logging configuration out of the properties
 		//


### PR DESCRIPTION
Hello Tim,

Just thought I'd squash this fairly trivial bug and tidy up the mixed indentation (!) while I was in the file.

Logging inside the configuration seemed like a smell to me, but at least it provides nice CLI output. Happy to adjust if need be.