### PR TITLE
Adds simple vector distance calculations for WorldCoordinates

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/application/EmitterStore.java
+++ b/codebase/src/java/disco/org/openlvc/disco/application/EmitterStore.java
@@ -32,7 +32,6 @@ import org.openlvc.disco.pdu.entity.EntityStatePdu;
 import org.openlvc.disco.pdu.field.BeamFunction;
 import org.openlvc.disco.pdu.record.EntityId;
 import org.openlvc.disco.pdu.record.WorldCoordinate;
-import org.openlvc.disco.utils.LLA;
 
 public class EmitterStore implements IDeleteReaperManaged
 {
@@ -128,8 +127,6 @@ public class EmitterStore implements IDeleteReaperManaged
 	
 	public Set<EmitterBeam> getActiveBeamsNear( WorldCoordinate location, int radiusMeters )
 	{
-		// Turn the target location into an LLA
-		LLA targetLLA = location.toLLA();
 
 		Set<EmitterBeam> beams = new HashSet<>();
 		
@@ -142,11 +139,10 @@ public class EmitterStore implements IDeleteReaperManaged
 			if( espdu == null )
 				continue; // no entity? ruh-roh
 			
-			// turn the entity location into an LLA
-			LLA entityLLA = espdu.getLocation().toLLA();
+			WorldCoordinate entityLocation = espdu.getLocation();
 			
 			// is this entity close to where our target is?
-			if( targetLLA.distanceBetweenHavershine(entityLLA) > radiusMeters )
+			if( WorldCoordinate.getStraightLineDistanceBetween(location, entityLocation) > radiusMeters )
 				continue;
 			
 			// we are in proximity; find all the active beams

--- a/codebase/src/java/disco/org/openlvc/disco/application/EntityStateStore.java
+++ b/codebase/src/java/disco/org/openlvc/disco/application/EntityStateStore.java
@@ -28,7 +28,6 @@ import org.openlvc.disco.DiscoException;
 import org.openlvc.disco.pdu.entity.EntityStatePdu;
 import org.openlvc.disco.pdu.record.EntityId;
 import org.openlvc.disco.pdu.record.WorldCoordinate;
-import org.openlvc.disco.utils.LLA;
 
 /**
  * Tracks the current state of all known {@link EntityStatePdu}s received from the network
@@ -156,12 +155,7 @@ public class EntityStateStore implements IDeleteReaperManaged
 	 */
 	public Set<EntityStatePdu> getEntityStatesNear( EntityStatePdu entity, int radiusMeters )
 	{
-		// only do this once
-		LLA target = entity.getLocation().toLLA();
-
-		return byId.values().parallelStream()
-		                    .filter( other -> target.distanceBetweenHavershine(other.getLocation().toLLA()) < radiusMeters )
-		                    .collect( Collectors.toSet() );
+		return getEntityStatesNear( entity.getLocation(), radiusMeters );
 	}
 	
 	/**
@@ -174,11 +168,8 @@ public class EntityStateStore implements IDeleteReaperManaged
 	 */
 	public Set<EntityStatePdu> getEntityStatesNear( WorldCoordinate location, int radiusMeters )
 	{
-		// only do this once
-		LLA target = location.toLLA();
-		
 		return byId.values().parallelStream()
-		                    .filter( other -> target.distanceBetweenHavershine(other.getLocation().toLLA()) < radiusMeters )
+		                    .filter( other -> WorldCoordinate.getStraightLineDistanceBetween(location, other.getLocation()) < radiusMeters )
 		                    .collect( Collectors.toSet() );
 	}
 

--- a/codebase/src/java/disco/org/openlvc/disco/pdu/record/WorldCoordinate.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/record/WorldCoordinate.java
@@ -177,5 +177,25 @@ public class WorldCoordinate implements IPduComponent, Cloneable
 	//----------------------------------------------------------
 	//                     STATIC METHODS
 	//----------------------------------------------------------
+	/**
+	 * Returns the straight line distance between two WorldCoordinate instances.
+	 * <p/>
+	 * Note: As the name suggests, this method measures the straight line distance between two points in
+	 * the WGS84 reference frame. It is ideally suited for points within the local horizon, or ground
+	 * to air calculations.
+	 * <p/>
+	 * For surface distances that span over the horizon, a great circle distance should be used
+	 * 
+	 * @param a the start WorldCoordinate
+	 * @param b the end WorldCoordinate
+	 * @return the straight-line distance between a and b, measured in meters
+	 */
+	public static double getStraightLineDistanceBetween( WorldCoordinate a, WorldCoordinate b )
+	{
+		double x = b.x - a.x;
+		double y = b.y - a.y;
+		double z = b.z - a.z;
+		return Math.sqrt( x*x + y*y + z*z );
+	}
 }
 


### PR DESCRIPTION
The havershine formula is used to calculate distances between two points in LLA space, however it is a relatively heavy operation.

When the two points are already expressed in the WGS84 (xyz) space, we can use a simple vector distance instead, which is much faster.