### PR TITLE
Adds custom PDU DccsWallclockTime

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/custom/dcss/mappers/WallclockTimeMapper.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/custom/dcss/mappers/WallclockTimeMapper.java
@@ -1,0 +1,184 @@
+/*
+ *   Copyright 2020 Open LVC Project.
+ *
+ *   This file is part of Open LVC Disco.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.openlvc.disco.connection.rpr.custom.dcss.mappers;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.openlvc.disco.DiscoException;
+import org.openlvc.disco.bus.EventHandler;
+import org.openlvc.disco.connection.rpr.custom.dcss.objects.WallclockTime;
+import org.openlvc.disco.connection.rpr.mappers.AbstractMapper;
+import org.openlvc.disco.connection.rpr.mappers.HlaDiscover;
+import org.openlvc.disco.connection.rpr.mappers.HlaReflect;
+import org.openlvc.disco.connection.rpr.model.AttributeClass;
+import org.openlvc.disco.connection.rpr.model.ObjectClass;
+import org.openlvc.disco.connection.rpr.model.ObjectModel;
+import org.openlvc.disco.pdu.field.PduType;
+
+import hla.rti1516e.AttributeHandleValueMap;
+import hla.rti1516e.encoding.ByteWrapper;
+import hla.rti1516e.encoding.DecoderException;
+
+public class WallclockTimeMapper extends AbstractMapper
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+	private static final String HLA_CLASS_NAME = "HLAobjectRoot.DCSSBaseObject.WallclockTime";
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private ObjectClass hlaClass;
+	private AttributeClass zuluTime;
+	private AttributeClass simulationTime;
+	private AttributeClass simulationElapsedTime;
+	private AttributeClass scalingFactor;
+	private AttributeClass simulationStartTime;
+	private AttributeClass clockState;
+	
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/// HLA Initialization   ///////////////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	@Override
+	protected void initialize() throws DiscoException
+	{
+		ObjectModel fom = rprConnection.getFom();
+		this.hlaClass = fom.getObjectClass( HLA_CLASS_NAME );
+		if( this.hlaClass == null )
+			throw new DiscoException( "Could not find class: "+HLA_CLASS_NAME );
+		
+		this.zuluTime = this.hlaClass.getAttribute( "ZuluTime" );
+		this.simulationTime = this.hlaClass.getAttribute( "SimulationTime" );
+		this.simulationElapsedTime = this.hlaClass.getAttribute( "SimulationElapsedTime" );
+		this.scalingFactor = this.hlaClass.getAttribute( "ScalingFactor" );
+		this.simulationStartTime = this.hlaClass.getAttribute( "SimulationStartTime" );
+		this.clockState = this.hlaClass.getAttribute( "ClockState" );
+		
+		// Do publication and subscription
+		super.publishAndSubscribe( hlaClass );
+	}
+	@Override
+	public Collection<PduType> getSupportedPdus()
+	{
+		return Arrays.asList( PduType.DcssWallclockTime );
+	}
+	
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/// HLA -> DIS Methods   ///////////////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	@EventHandler
+	public void handleDiscover( HlaDiscover event )
+	{
+		if( hlaClass == event.theClass )
+		{
+			WallclockTime hlaObject = new WallclockTime();
+			hlaObject.setObjectClass( event.theClass );
+			hlaObject.setObjectHandle( event.theObject );
+			objectStore.addDiscoveredHlaObject( hlaObject );
+
+			if( logger.isDebugEnabled() )
+			{
+				logger.debug( "hla >> dis (Discover) Created [%s] for discovery of object handle [%s]",
+				              event.theClass.getLocalName(), 
+				              event.theObject );
+			}
+			
+			// Request an attribute update for the object so that we can get everything we need
+			super.requestAttributeUpdate( hlaObject );
+		}
+	}
+
+	@EventHandler
+	public void handleReflect( HlaReflect event )
+	{
+		if( (event.hlaObject instanceof WallclockTime) == false )
+			return;
+		
+		try
+		{
+			// Update the local object representation from the received attributes
+			deserializeFromHla( (WallclockTime)event.hlaObject, event.attributes );
+		}
+		catch( DecoderException de )
+		{
+			throw new DiscoException( de.getMessage(), de );
+		}
+		
+		// Send the PDU off to the OpsCenter
+		// FIXME - We serialize it to a byte[], but it will be turned back into a PDU
+		//         on the other side. This is inefficient and distasteful. Fix me.
+		opscenter.getPduReceiver().receive( event.hlaObject.toPdu().toByteArray() );
+	}
+	
+	private void deserializeFromHla( WallclockTime time, AttributeHandleValueMap map )
+		throws DecoderException
+	{
+		if( map.containsKey(zuluTime.getHandle()) )
+		{
+			ByteWrapper wrapper = new ByteWrapper( map.get(zuluTime.getHandle()) );
+			time.getZuluTime().decode( wrapper );
+		}
+		
+		if( map.containsKey(simulationTime.getHandle()) )
+		{
+			ByteWrapper wrapper = new ByteWrapper( map.get(simulationTime.getHandle()) );
+			time.getSimulationTime().decode( wrapper );
+		}
+		
+		if( map.containsKey(simulationElapsedTime.getHandle()) )
+		{
+			ByteWrapper wrapper = new ByteWrapper( map.get(simulationElapsedTime.getHandle()) );
+			time.getSimulationElapsedTime().decode( wrapper );
+		}
+		
+		if( map.containsKey(scalingFactor.getHandle()) )
+		{
+			ByteWrapper wrapper = new ByteWrapper( map.get(scalingFactor.getHandle()) );
+			time.getScalingFactor().decode( wrapper );
+		}
+		
+		if( map.containsKey(simulationStartTime.getHandle()) )
+		{
+			ByteWrapper wrapper = new ByteWrapper( map.get(simulationStartTime.getHandle()) );
+			time.getSimulationStartTime().decode( wrapper );
+		}
+		
+		if( map.containsKey(clockState.getHandle()) )
+		{
+			ByteWrapper wrapper = new ByteWrapper( map.get(clockState.getHandle()) );
+			time.getClockState().decode( wrapper );
+		}
+	}
+	
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/// Accessor and Mutator Methods   /////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/custom/dcss/objects/WallclockTime.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/custom/dcss/objects/WallclockTime.java
@@ -1,0 +1,135 @@
+/*
+ *   Copyright 2020 Open LVC Project.
+ *
+ *   This file is part of Open LVC Disco.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.openlvc.disco.connection.rpr.custom.dcss.objects;
+
+import org.openlvc.disco.connection.rpr.custom.dcss.types.enumerated.ClockStateEnum;
+import org.openlvc.disco.connection.rpr.objects.ObjectInstance;
+import org.openlvc.disco.connection.rpr.types.basic.RPRunsignedInteger32BE;
+import org.openlvc.disco.connection.rpr.types.fixed.ClockTimeStruct;
+import org.openlvc.disco.connection.rpr.types.simple.Float32;
+import org.openlvc.disco.pdu.PDU;
+import org.openlvc.disco.pdu.custom.DcssWallclockTimePdu;
+import org.openlvc.disco.pdu.record.EntityId;
+
+public class WallclockTime extends ObjectInstance
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private ClockTimeStruct zuluTime;
+	private ClockTimeStruct simulationTime;
+	private RPRunsignedInteger32BE simulationElapsedTime;
+	private Float32 scalingFactor;
+	private ClockTimeStruct simulationStartTime;
+	private ClockStateEnum clockState;
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public WallclockTime()
+	{
+		this.zuluTime = new ClockTimeStruct();
+		this.simulationTime = new ClockTimeStruct();
+		this.simulationElapsedTime = new RPRunsignedInteger32BE();
+		this.scalingFactor = new Float32();
+		this.simulationStartTime = new ClockTimeStruct();
+		this.clockState = ClockStateEnum.Paused;
+	}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	@Override
+	public void fromPdu( PDU pdu )
+	{
+		DcssWallclockTimePdu asWallclock = pdu.as( DcssWallclockTimePdu.class );
+		this.zuluTime.setDisValue( asWallclock.getZuluTime() );
+		this.simulationTime.setDisValue( asWallclock.getSimulationTime() );
+		this.simulationElapsedTime.setValue( asWallclock.getSimulationElapsedTime() );
+		this.scalingFactor.setValue( asWallclock.getScalingFactor() );
+		this.simulationStartTime.setDisValue( asWallclock.getSimulationStartTime() );
+		this.clockState = ClockStateEnum.valueOf( asWallclock.getClockState() );
+	}
+	
+	@Override
+	public DcssWallclockTimePdu toPdu()
+	{
+		DcssWallclockTimePdu pdu = new DcssWallclockTimePdu();
+		pdu.setZuluTime( this.zuluTime.getDisValue() );
+		pdu.setSimulationTime( this.simulationTime.getDisValue() );
+		pdu.setSimulationElapsedTime( this.simulationElapsedTime.getValue() );
+		pdu.setScalingFactor( this.scalingFactor.getValue() );
+		pdu.setSimulationStartTime( this.simulationStartTime.getDisValue() );
+		pdu.setClockState( this.clockState.getValue() );
+		
+		return pdu;
+	}
+	@Override
+	public EntityId getDisId()
+	{
+		return null;
+	}
+	
+	@Override
+	protected boolean checkReady()
+	{
+		return simulationTime.isDecodeCalled();
+	}
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/// Accessor and Mutator Methods   /////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	public ClockTimeStruct getZuluTime()
+	{
+		return this.zuluTime;
+	}
+	
+	public ClockTimeStruct getSimulationTime()
+	{
+		return this.simulationTime;
+	}
+	
+	public RPRunsignedInteger32BE getSimulationElapsedTime()
+	{
+		return this.simulationElapsedTime;
+	}
+	
+	public Float32 getScalingFactor()
+	{
+		return this.scalingFactor;
+	}
+	
+	public ClockTimeStruct getSimulationStartTime()
+	{
+		return this.simulationStartTime;
+	}
+	
+	public ClockStateEnum getClockState()
+	{
+		return this.clockState;
+	}
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/custom/dcss/types/enumerated/ClockStateEnum.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/custom/dcss/types/enumerated/ClockStateEnum.java
@@ -1,0 +1,114 @@
+/*
+ *   Copyright 2020 Open LVC Project.
+ *
+ *   This file is part of Open LVC Disco.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.openlvc.disco.connection.rpr.custom.dcss.types.enumerated;
+
+import org.openlvc.disco.connection.rpr.types.basic.HLAoctet;
+import org.openlvc.disco.connection.rpr.types.enumerated.ExtendedDataElement;
+
+import hla.rti1516e.encoding.ByteWrapper;
+import hla.rti1516e.encoding.DecoderException;
+import hla.rti1516e.encoding.EncoderException;
+
+public enum ClockStateEnum implements ExtendedDataElement<ClockStateEnum>
+{
+	//----------------------------------------------------------
+	//                        VALUES
+	//----------------------------------------------------------
+	Paused( new HLAoctet(0) ),
+	Running( new HLAoctet(1) ),
+	Error( new HLAoctet(2) );
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private HLAoctet value;
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	private ClockStateEnum( HLAoctet value )
+	{
+		this.value = value;
+	}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	public byte getValue()
+	{
+		return this.value.getValue();
+	}
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/// Data Element Methods   /////////////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	@Override
+	public int getOctetBoundary()
+	{
+		return value.getOctetBoundary();
+	}
+
+	@Override
+	public void encode( ByteWrapper byteWrapper ) throws EncoderException
+	{
+		value.encode( byteWrapper );
+	}
+
+
+	@Override
+	public int getEncodedLength()
+	{
+		return value.getEncodedLength();
+	}
+
+
+	@Override
+	public byte[] toByteArray() throws EncoderException
+	{
+		return value.toByteArray();
+	}
+
+
+	@Override
+	public ClockStateEnum valueOf( ByteWrapper value ) throws DecoderException
+	{
+		HLAoctet temp = new HLAoctet();
+		temp.decode( value );
+		return valueOf( temp.getValue() );
+	}
+
+	@Override
+	public ClockStateEnum valueOf( byte[] value ) throws DecoderException
+	{
+		HLAoctet temp = new HLAoctet();
+		temp.decode( value );
+		return valueOf( temp.getValue() );
+	}
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	public static ClockStateEnum valueOf( byte value )
+	{
+		for( ClockStateEnum temp : ClockStateEnum.values() )
+			if( temp.value.getValue() == value )
+				return temp;
+		
+		throw new IllegalArgumentException( "Unknown enumerator value: "+value+" (ClockStateEnum)" );
+	}
+}

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/types/fixed/ClockTimeStruct.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/types/fixed/ClockTimeStruct.java
@@ -1,0 +1,94 @@
+/*
+ *   Copyright 2020 Open LVC Project.
+ *
+ *   This file is part of Open LVC Disco.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.openlvc.disco.connection.rpr.types.fixed;
+
+import org.openlvc.disco.connection.rpr.types.basic.HLAinteger32BE;
+import org.openlvc.disco.connection.rpr.types.basic.RPRunsignedInteger32BE;
+import org.openlvc.disco.pdu.record.ClockTime;
+
+public class ClockTimeStruct extends WrappedHlaFixedRecord
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private HLAinteger32BE hours;
+	private RPRunsignedInteger32BE timePastTheHour;
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public ClockTimeStruct()
+	{
+		this.hours = new HLAinteger32BE();
+		this.timePastTheHour = new RPRunsignedInteger32BE();
+		
+		super.add( this.hours );
+		super.add( this.timePastTheHour );
+	}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/// Accessor and Mutator Methods   /////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/// DIS Mappings Methods   /////////////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	public int getHours()
+	{
+		return this.hours.getValue();
+	}
+	
+	public void setHours( int hours )
+	{
+		this.hours.setValue( hours );
+	}
+	
+	public long getTimePastHour()
+	{
+		return this.timePastTheHour.getValue();
+	}
+	
+	public void setTimePastHour( long time )
+	{
+		this.timePastTheHour.setValue( time );
+	}
+	
+	public ClockTime getDisValue()
+	{
+		return new ClockTime( this.hours.getValue(), 
+		                      this.timePastTheHour.getValue() );
+	}
+	
+	public void setDisValue( ClockTime value )
+	{
+		this.hours.setValue( value.getHours() );
+		this.timePastTheHour.setValue( value.getTimePastTheHour() );
+	}
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/types/simple/Float32.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/types/simple/Float32.java
@@ -1,0 +1,47 @@
+/*
+ *   Copyright 2020 Open LVC Project.
+ *
+ *   This file is part of Open LVC Disco.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.openlvc.disco.connection.rpr.types.simple;
+
+import org.openlvc.disco.connection.rpr.types.basic.HLAfloat32BE;
+
+public class Float32 extends HLAfloat32BE
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/// Accessor and Mutator Methods   /////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/disco/org/openlvc/disco/pdu/custom/DcssWallclockTimePdu.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/custom/DcssWallclockTimePdu.java
@@ -1,0 +1,174 @@
+/*
+ *   Copyright 2020 Open LVC Project.
+ *
+ *   This file is part of Open LVC Disco.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.openlvc.disco.pdu.custom;
+
+import java.io.IOException;
+
+import org.openlvc.disco.pdu.DisInputStream;
+import org.openlvc.disco.pdu.DisOutputStream;
+import org.openlvc.disco.pdu.PDU;
+import org.openlvc.disco.pdu.field.PduType;
+import org.openlvc.disco.pdu.record.ClockTime;
+
+public class DcssWallclockTimePdu extends PDU
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private ClockTime zuluTime;            /** Zulu wallclock time **/
+	private ClockTime simulationTime;      /** Simulation time of day. **/
+	private long simulationElapsedTime;    /** Time in milliseconds since the start of the simulation. **/
+	private float scalingFactor;           /** Multiplier for clock time, e.g. 2x speed, 0.5x speed. **/
+	private ClockTime simulationStartTime; /** Clock time when the simulation started. **/
+	private byte clockState;               /** State of clock - started, paused or in an error state. **/
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public DcssWallclockTimePdu()
+	{
+		super( PduType.DcssWallclockTime );
+		this.zuluTime = new ClockTime();
+		this.simulationTime = new ClockTime();
+		this.simulationElapsedTime = 0;
+		this.scalingFactor = 0.0f;
+		this.simulationStartTime = new ClockTime();
+		this.clockState = 0;
+	}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/// IPduComponent Methods   ////////////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	@Override
+	public void from( DisInputStream dis ) throws IOException
+	{
+		this.zuluTime.from( dis );
+		this.simulationTime.from( dis );
+		this.simulationElapsedTime = dis.readUI32();
+		this.scalingFactor = dis.readFloat();
+		this.simulationStartTime.from( dis );
+		this.clockState = dis.readByte();
+	}
+
+	@Override
+	public void to( DisOutputStream dos ) throws IOException
+	{
+		this.zuluTime.to( dos );
+		this.simulationTime.to( dos );
+		dos.writeUI32( this.simulationElapsedTime );
+		dos.writeFloat( this.scalingFactor );
+		this.simulationStartTime.to( dos );
+		dos.writeByte( this.clockState );
+	}
+
+	@Override
+	public final int getContentLength()
+	{
+		return 33;
+	}
+	
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/// Filtering Support Methods   ////////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	@Override
+	public int getSiteId()
+	{
+		return 0;
+	}
+
+	@Override
+	public int getAppId()
+	{
+		return 0;
+	}
+	
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/// Accessor and Mutator Methods   /////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	public ClockTime getZuluTime()
+	{
+		return this.zuluTime;
+	}
+	
+	public void setZuluTime( ClockTime zuluTime )
+	{
+		this.zuluTime = zuluTime;
+	}
+	
+	public ClockTime getSimulationTime()
+	{
+		return this.simulationTime;
+	}
+	
+	public void setSimulationTime( ClockTime simulationTime )
+	{
+		this.simulationTime = simulationTime;
+	}
+	
+	public long getSimulationElapsedTime()
+	{
+		return this.simulationElapsedTime;
+	}
+	
+	public void setSimulationElapsedTime( long elapsedTime )
+	{
+		this.simulationElapsedTime = elapsedTime;
+	}
+	
+	public float getScalingFactor()
+	{
+		return this.scalingFactor;
+	}
+	
+	public void setScalingFactor( float scalingFactor )
+	{
+		this.scalingFactor = scalingFactor;
+	}
+	
+	public ClockTime getSimulationStartTime()
+	{
+		return this.simulationStartTime;
+	}
+	
+	public void setSimulationStartTime( ClockTime startTime )
+	{
+		this.simulationStartTime = startTime;
+	}
+	
+	public byte getClockState()
+	{
+		return this.clockState;
+	}
+	
+	public void setClockState( byte state )
+	{
+		this.clockState = state;
+	}
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/disco/org/openlvc/disco/pdu/field/PduType.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/field/PduType.java
@@ -140,7 +140,7 @@ public enum PduType
 	IRCUser           ( (short)160, ProtocolFamily.DiscoCustom,    IrcUserPdu.class ),
 	IRCMessage        ( (short)161, ProtocolFamily.DiscoCustom,    IrcMessagePdu.class ),
 	IRCRawMessage     ( (short)162, ProtocolFamily.DiscoCustom,    IrcRawMessagePdu.class ),
-  DcssWallclockTime ( (short)170, ProtocolFamily.DiscoCustom,    DcssWallclockTimePdu.class );
+	DcssWallclockTime ( (short)170, ProtocolFamily.DiscoCustom,    DcssWallclockTimePdu.class );
 	
 	//----------------------------------------------------------
 	//                    STATIC VARIABLES

--- a/codebase/src/java/disco/org/openlvc/disco/pdu/field/PduType.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/field/PduType.java
@@ -41,6 +41,7 @@ import org.openlvc.disco.pdu.simman.DataPdu;
 import org.openlvc.disco.pdu.simman.SetDataPdu;
 import org.openlvc.disco.pdu.warfare.DetonationPdu;
 import org.openlvc.disco.pdu.warfare.FirePdu;
+import org.openlvc.disco.pdu.custom.DcssWallclockTimePdu;
 import org.openlvc.disco.pdu.custom.IrcMessagePdu;
 import org.openlvc.disco.pdu.custom.IrcRawMessagePdu;
 import org.openlvc.disco.pdu.custom.IrcUserPdu;
@@ -138,7 +139,8 @@ public enum PduType
 	// Custom Extensions
 	IRCMessage        ( (short)160, ProtocolFamily.DiscoCustom,    IrcMessagePdu.class ),
 	IRCRawMessage     ( (short)161, ProtocolFamily.DiscoCustom,    IrcRawMessagePdu.class ),
-	IRCUser           ( (short)162, ProtocolFamily.DiscoCustom,    IrcUserPdu.class );
+	IRCUser           ( (short)162, ProtocolFamily.DiscoCustom,    IrcUserPdu.class ),
+	DcssWallclockTime ( (short)170, ProtocolFamily.DiscoCustom,    DcssWallclockTimePdu.class );
 	
 	//----------------------------------------------------------
 	//                    STATIC VARIABLES

--- a/codebase/src/java/disco/org/openlvc/disco/pdu/record/ClockTime.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/record/ClockTime.java
@@ -1,0 +1,142 @@
+/*
+ *   Copyright 2020 Open LVC Project.
+ *
+ *   This file is part of Open LVC Disco.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.openlvc.disco.pdu.record;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import org.openlvc.disco.pdu.DisInputStream;
+import org.openlvc.disco.pdu.DisOutputStream;
+import org.openlvc.disco.pdu.IPduComponent;
+
+public class ClockTime implements IPduComponent, Cloneable
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private int hours;
+	private long timePastTheHour; 
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public ClockTime()
+	{
+		this( 0, 0L );
+	}
+	
+	public ClockTime( int hours, long timePastTheHour )
+	{
+		this.hours = hours;
+		this.timePastTheHour = timePastTheHour;
+	}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	public ClockTime clone()
+	{
+		return new ClockTime( this.hours, this.timePastTheHour );
+	}
+	
+	@Override
+	public boolean equals( Object other )
+	{
+		boolean equal = false;
+		if( other instanceof ClockTime )
+		{
+			ClockTime asClock = (ClockTime)other;
+			equal = asClock.hours == this.hours && 
+			        asClock.timePastTheHour == this.timePastTheHour;
+		}
+		
+		return equal;
+	}
+	
+	
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/// IPduComponent Methods   ////////////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	@Override
+	public void from( DisInputStream dis ) throws IOException
+	{
+		this.hours = dis.readInt();
+		this.timePastTheHour = dis.readUI32();
+	}
+
+	@Override
+	public void to( DisOutputStream dos ) throws IOException
+	{
+		dos.writeInt( this.hours );
+		dos.writeUI32( this.timePastTheHour );
+	}
+
+	@Override
+	public final int getByteLength()
+	{
+		return 8;
+	}
+	
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/// Accessor and Mutator Methods   /////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	public int getHours()
+	{
+		return this.hours;
+	}
+	
+	public void setHours( int hours )
+	{
+		this.hours = hours;
+	}
+	
+	public long getTimePastTheHour()
+	{
+		return this.timePastTheHour;
+	}
+	
+	public void setTimePastTheHour( long timePastTheHour )
+	{
+		this.timePastTheHour = timePastTheHour;
+	}
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	public static ClockTime fromJavaTime( long time )
+	{
+		final long RANGE = 0xFFFFFFFFL;
+		Calendar cal = Calendar.getInstance( TimeZone.getTimeZone("UTC") );
+		cal.setTimeInMillis( time );
+		Instant instant = cal.toInstant();
+		long epochSeconds = instant.getEpochSecond();
+		double epochHours = epochSeconds / 60.0;
+		int epochHourIntegral = (int)Math.floor( epochHours );
+		double timePastHourFraction = epochHours - epochHourIntegral;
+		long timePastHour = Math.round( RANGE * timePastHourFraction );
+		
+		return new ClockTime( epochHourIntegral, timePastHour );
+	}
+}

--- a/codebase/src/java/test/org/openlvc/disco/pdu/custom/DcssWallclockTimePduTest.java
+++ b/codebase/src/java/test/org/openlvc/disco/pdu/custom/DcssWallclockTimePduTest.java
@@ -126,17 +126,4 @@ public class DcssWallclockTimePduTest extends AbstractTest
 	//----------------------------------------------------------
 	//                     STATIC METHODS
 	//----------------------------------------------------------
-	public static void main( String[] args )
-	{
-		DcssWallclockTimePduTest test = new DcssWallclockTimePduTest();
-		
-		try
-		{
-			test.testDcssWallclockTimePduPduSerialize();
-		}
-		catch( Exception e )
-		{
-			e.printStackTrace();
-		}
-	}
 }

--- a/codebase/src/java/test/org/openlvc/disco/pdu/custom/DcssWallclockTimePduTest.java
+++ b/codebase/src/java/test/org/openlvc/disco/pdu/custom/DcssWallclockTimePduTest.java
@@ -1,0 +1,142 @@
+/*
+ *   Copyright 2020 Open LVC Project.
+ *
+ *   This file is part of Open LVC Disco.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.openlvc.disco.pdu.custom;
+
+import java.time.Month;
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import org.openlvc.disco.AbstractTest;
+import org.openlvc.disco.connection.rpr.custom.dcss.types.enumerated.ClockStateEnum;
+import org.openlvc.disco.pdu.PduFactory;
+import org.openlvc.disco.pdu.record.ClockTime;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(groups= {"pdu","custom","dcss"})
+public class DcssWallclockTimePduTest extends AbstractTest
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	///////////////////////////////////////////////////////////////////////////////////
+	/// Test Class Setup/Tear Down   //////////////////////////////////////////////////
+	///////////////////////////////////////////////////////////////////////////////////
+	@BeforeClass(alwaysRun=true)
+	public void beforeClass()
+	{
+	}
+	
+	@BeforeMethod(alwaysRun=true)
+	public void beforeMethod()
+	{
+	}
+
+	@AfterMethod(alwaysRun=true)
+	public void afterMethod()
+	{
+	}
+	
+	@AfterClass(alwaysRun=true)
+	public void afterClass()
+	{
+	}
+
+	///////////////////////////////////////////////////////////////////////////////////
+	/// PDU Testing Methods   /////////////////////////////////////////////////////////
+	///////////////////////////////////////////////////////////////////////////////////
+	@Test
+	public void testDcssWallclockTimePduPduSerialize() throws Exception
+	{
+
+		DcssWallclockTimePdu before = new DcssWallclockTimePdu();
+		Calendar calendar = Calendar.getInstance( TimeZone.getTimeZone("UTC") );
+		
+		// Zulu Time
+		calendar.set( 2020, Month.AUGUST.getValue()-1, 13, 14, 15, 16 );
+		long zuluTimeMillis = calendar.getTimeInMillis();
+		before.setZuluTime( ClockTime.fromJavaTime(zuluTimeMillis) );
+		
+		// Simulation Time
+		calendar.set( 2010, Month.JULY.getValue()-1, 8, 19, 20, 21 );
+		long simTimeMillis = calendar.getTimeInMillis();
+		before.setSimulationTime( ClockTime.fromJavaTime(simTimeMillis) );
+		
+		// ElapsedTime - 1hr 43m 23s 567ms
+		long elapsedTime = 1*60*60*1000 + 43*60*1000 + 23*1000 + 567;
+		before.setSimulationElapsedTime( elapsedTime );
+		
+		// Scaling Factor
+		before.setScalingFactor( 1.0f );
+
+		// Simulation Start Time (FOM says clock time at start of simulation, but doesn't say which clock!
+		// assuming its the wallclock, as you could easily interpolate the simulation clock start time
+		// by SimulationTime - ElapsedTime. 
+		long startTimeMillis = zuluTimeMillis - elapsedTime;
+		before.setSimulationStartTime( ClockTime.fromJavaTime(startTimeMillis) );
+		
+		before.setClockState( ClockStateEnum.Running.getValue() );
+		
+		// turn the PDU into a byte[]
+		byte[] beforeArray = before.toByteArray();
+		
+		// convert it back
+		DcssWallclockTimePdu after = PduFactory.create( beforeArray );
+		
+		// compare the pair!
+		Assert.assertEquals( after.getZuluTime(),              before.getZuluTime() );
+		Assert.assertEquals( after.getSimulationTime(),        before.getSimulationTime() );
+		Assert.assertEquals( after.getSimulationElapsedTime(), before.getSimulationElapsedTime() );
+		Assert.assertEquals( after.getSimulationStartTime(),   before.getSimulationStartTime() );
+		Assert.assertEquals( after.getClockState(),            before.getClockState() );
+	}
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	public static void main( String[] args )
+	{
+		DcssWallclockTimePduTest test = new DcssWallclockTimePduTest();
+		
+		try
+		{
+			test.testDcssWallclockTimePduPduSerialize();
+		}
+		catch( Exception e )
+		{
+			e.printStackTrace();
+		}
+	}
+}


### PR DESCRIPTION
- The purpose of this PDU is to advertise simulated and wallclock time within a DCSS simulation
- The PDU is mapped to the "WallclockTime" in the DCSS HLA FOM
- ClockTimeStruct attributes are mapped to IEEE1278.1 ClockTime record.