### PR TITLE
Update RPR connection to populate HostObjectIdentifer in RadioTransmitter

### DIFF
--- a/codebase/profiles/java.xml
+++ b/codebase/profiles/java.xml
@@ -68,7 +68,7 @@
 	<property name="marineapi.dir"         location="${lib.dir}/marineapi/0.10.0"/> <!-- NEMA 0183 Formatting -->
 	<!-- HLA Settings -->
 	<property name="ieee1516e.dir"         location="${lib.dir}/hla/ifspec"/> <!-- HLA IfSpec -->
-	<property name="portico.dir"           location="${lib.dir}/hla/portico/2.0.3"/> <!-- Portico, for HLA testing -->
+	<property name="portico.dir"           location="${lib.dir}/hla/portico/2.0.4"/> <!-- Portico, for HLA testing -->
 
 	<!-- Classpaths for individual libraries -->
 	<path id="lib.testng.classpath">

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/RprConnection.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/RprConnection.java
@@ -586,6 +586,7 @@ public class RprConnection implements IConnection
 		
 		// Slam the arrays together and return
 		return Stream.concat( Arrays.stream(createModules), Arrays.stream(joinModules) )
+		//return Stream.concat( Arrays.stream(joinModules), Arrays.stream(createModules) )
 		             .toArray( URL[]::new );
 	}
 		

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/mappers/EntityStateMapper.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/mappers/EntityStateMapper.java
@@ -832,6 +832,10 @@ public class EntityStateMapper extends AbstractMapper
 		{
 			opscenter.getPduReceiver().receive( rprEntity.toPdu().toByteArray() );
 			event.hlaObject.setLastUpdatedTimeToNow();
+			
+			// We need to update the object store so that is has an accurate list of
+			// objects by entity id so that we can look up RPR object by DIS site/app/entity id.
+			objectStore.updateRtiIdForDisId( rprEntity.getDisId(), rprEntity.getRtiObjectId() );
 		}
 	}
 	

--- a/codebase/src/java/disco/org/openlvc/disco/pdu/radio/TransmitterPdu.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/radio/TransmitterPdu.java
@@ -31,6 +31,7 @@ import org.openlvc.disco.pdu.field.InputSource;
 import org.openlvc.disco.pdu.field.PduType;
 import org.openlvc.disco.pdu.field.TransmitState;
 import org.openlvc.disco.pdu.record.AntennaLocation;
+import org.openlvc.disco.pdu.record.FullRadioId;
 import org.openlvc.disco.pdu.record.EntityId;
 import org.openlvc.disco.pdu.record.ModulationType;
 import org.openlvc.disco.pdu.record.RadioEntityType;
@@ -209,6 +210,11 @@ public class TransmitterPdu extends PDU
 	public EntityId getEntityIdentifier()
 	{
 		return entityID;
+	}
+	
+	public FullRadioId getFullRadioId()
+	{
+		return new FullRadioId( this.entityID, this.radioId );
 	}
 	
 	public void setEntityId( EntityId id )

--- a/codebase/src/java/disco/org/openlvc/disco/pdu/record/FullRadioId.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/record/FullRadioId.java
@@ -1,0 +1,99 @@
+/*
+ *   Copyright 2021 Open LVC Project.
+ *
+ *   This file is part of Open LVC Disco.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.openlvc.disco.pdu.record;
+
+/**
+ * THIS DOES NOT REPRESENT A STANDARD DIS TYPE.<p/>
+ * 
+ * This class is used for internal purposes primarily. It aggregated a DIS {@link EntityId} with
+ * a forth radio id field.<p/>
+ * 
+ * It is not an IPduComponent, and it provided only as a convenient wrapper for identifying
+ * radios uniquely.
+ */
+public class FullRadioId
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private EntityId entityId;
+	private int radioId;
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public FullRadioId( EntityId entityId, int radioId )
+	{
+		this.entityId = entityId;
+		this.radioId = radioId;
+	}
+	
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/// Accessor and Mutator Methods   /////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	@Override
+	public boolean equals( Object value )
+	{
+		if( value != null && value instanceof FullRadioId )
+		{
+			FullRadioId other = (FullRadioId)value;
+			return (other.radioId == this.radioId) &&
+			       (other.entityId.equals(this.entityId));
+		}
+		
+		return false;
+	}
+	
+	@Override
+	public final int hashCode()
+	{
+		return (entityId.toString()+"-"+radioId).hashCode();
+	}
+	
+	public EntityId getEntityId()
+	{
+		return entityId;
+	}
+
+	public void setEntityId( EntityId entityId )
+	{
+		this.entityId = entityId;
+	}
+
+	public int getRadioId()
+	{
+		return radioId;
+	}
+
+	public void setRadioId( int radioId )
+	{
+		this.radioId = radioId;
+	}
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/disco/org/openlvc/disco/utils/NetworkUtils.java
+++ b/codebase/src/java/disco/org/openlvc/disco/utils/NetworkUtils.java
@@ -373,6 +373,8 @@ public class NetworkUtils
 	}
 
 	/**
+	 * Create and return a pair of datagram sockets configured to use the broadcast address
+	 * associated with the given IP address. 
 	 * Creates a pair of datagram sockets (one for sending, one for listening/receiving) configured
 	 * to use broadcast and returns them. The sender socket will be bound to an ephemeral port as
 	 * its source. The receiver socket will listen on the provided port. This is done to allow

--- a/codebase/src/java/test/org/openlvc/disco/common/TestListener.java
+++ b/codebase/src/java/test/org/openlvc/disco/common/TestListener.java
@@ -93,7 +93,7 @@ public class TestListener implements IPduListener
 		if( marking.length() > 11 )
 			throw new RuntimeException( "Marking cannot be longer than 11 characters ["+marking+"]" );
 		
-		long finishTime = getTimeout();
+		long finishTime = getWaitUntilTime();
 		while( finishTime > System.currentTimeMillis() )
 		{
 			waitForPdu();
@@ -108,7 +108,7 @@ public class TestListener implements IPduListener
 	
 	public TransmitterPdu waitForTransmitter( EntityId id )
 	{
-		long finishTime = getTimeout();
+		long finishTime = getWaitUntilTime();
 		while( finishTime > System.currentTimeMillis() )
 		{
 			waitForPdu();
@@ -123,7 +123,7 @@ public class TestListener implements IPduListener
 	
 	public SignalPdu waitForSignal( EntityId id )
 	{
-		long finishTime = getTimeout();
+		long finishTime = getWaitUntilTime();
 		while( finishTime > System.currentTimeMillis() )
 		{
 			waitForPdu();
@@ -139,14 +139,14 @@ public class TestListener implements IPduListener
 	///////////////////////////////////////////////////////////////////////////////////
 	/// Helper Methods   //////////////////////////////////////////////////////////////
 	///////////////////////////////////////////////////////////////////////////////////
-	private long getTimeout()
+	private long getWaitUntilTime()
 	{
 		return System.currentTimeMillis() + CommonSetup.TIMEOUT+10;
 	}
 	
 	private void waitForPdu()
 	{
-		waitForPdu( getTimeout() );
+		waitForPdu( CommonSetup.TIMEOUT );
 	}
 	
 	//private void waitForPduUntil( long time )


### PR DESCRIPTION
Many issues here:

 * Portico would not work due to FOM parser issues (didn't fix, just temporarily
   hacked around and undid that change before commit)

 * Portico encoding helpers were bad, so I went and fixed those and updated the portico version in the repo.

 * Disco-RPR was not looking at the DIS entity ID and using it to populate the HostObjectIdentifier field - FIXED

 * Disco-RPR can't tell when a locally created DIS radio changes its ID (it looks like a different radio). Hacked
   some temporary stuff to identify changed IDs when CNR default config values are used (1-1-0, 1-1-1 or 0-0-0 for
   site-app-entity id). Can detect change from default to non-default, but can’t detect the reverse (if
   entity attachment is dropped).

There are some deeper issues here. In CNR/DIS, when a radio attaches to a platform it changes its entity id to
match that of the host platform. Unfortunately there is no way to tell the difference between a TramistterPDU
that has just changed its ID and an entirely different transmitter. This meant that when a change would happen,
it would cause us to register an entirely new HLA object and start updating it.

I've fixed this "mostly" now, but it will only work for CNR applications IF they use the default site/app/entity
id configuration settings. Otherwise, we’ll get duplicate objects. The old ones should time out and go away
eventually, but I’m not going down that rabbit hole.