### PR TITLE
Fixes broadcast socket setup issues on non-windows machines

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/connection/UdpConnection.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/UdpConnection.java
@@ -38,7 +38,6 @@ import org.openlvc.disco.pdu.PDU;
 import org.openlvc.disco.pdu.PduFactory;
 import org.openlvc.disco.pdu.field.PduType;
 import org.openlvc.disco.utils.NetworkUtils;
-import org.openlvc.disco.utils.Platform;
 import org.openlvc.disco.utils.SocketOptions;
 import org.openlvc.disco.utils.StringUtils;
 
@@ -147,22 +146,12 @@ public class UdpConnection implements IConnection
 		}
 		else
 		{
-			//
-			// Create a BROADCAST socket
-			//
-			// If we are linux or mac, we have to use the broadcast address. However if we are on
-			// windows, we cannot bind to the broadcast address, we have to bind to the actual
-			// NIC address.
-			// 
-			if( Platform.getOperatingSystem() == Platform.OS.Windows )
-				address = NetworkUtils.getFirstIPv4Address( networkInterface );
-			else
-				address = networkInterface.getInterfaceAddresses().get(0).getBroadcast();
-
 			logger.info( "Connecting broadcast socket - %s:%d (interface: %s)", address, port, networkInterface );
 			
-			// Create the socket pair
-			DatagramSocket[] pair = NetworkUtils.createBroadcastPair( address, port, networkInterface, options );
+			//
+			// Create a BROADCAST socket
+			// 			
+			DatagramSocket[] pair = NetworkUtils.createBroadcastPair( port, networkInterface, options );
 			this.sendSocket = pair[0];
 			this.recvSocket = pair[1];
 		}


### PR DESCRIPTION
- After some experimenting I think I've arrived at a setup that works
  * Windows -> Windows
  * Windows -> Linux
  * Linux -> Windows
  * Linux -> Linux.
- The address that the send socket is bound to is independent of the platform. In all cases it should be bound to the address of the NIC that is being used
- The address that the receive socket is bound to depends on the platform. 
  * Under linux etc the recv socket is bound to the broadcast address
  * Under windows it is bound to the NIC address (same as the send socket).