### PR TITLE
Enable Mak RTI use

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/OpsCenter.java
+++ b/codebase/src/java/disco/org/openlvc/disco/OpsCenter.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.apache.logging.log4j.Logger;
 import org.openlvc.disco.configuration.DiscoConfiguration;
+import org.openlvc.disco.configuration.RprConfiguration.RtiProvider;
 import org.openlvc.disco.connection.ConnectionFactory;
 import org.openlvc.disco.connection.IConnection;
 import org.openlvc.disco.connection.Metrics;
@@ -169,8 +170,15 @@ public class OpsCenter
 				logger.warn( "Missing jar file: "+file.getAbsolutePath() );
 		}
 		
-		ClassLoaderUtils.extendClasspath( configuration.getRprConfiguration().getRtiPathExtension() );
+		ClassLoaderUtils.extendClasspath( paths );
 		logger.debug( "Extended classpath to include HLA libraries; added: "+paths );
+		
+		// Mak is too cool for the classpath, it needs to be put on the library path
+		if( configuration.getRprConfiguration().getRtiProvider() == RtiProvider.Mak )
+		{
+			ClassLoaderUtils.extendLibraryPath( paths );
+			logger.debug( "Extended Java library path to include HLA libraries; added: "+paths );
+		}
 	}
 
 	////////////////////////////////////////////////////////////////////////////////////////////

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/mappers/TransmitterMapper.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/mappers/TransmitterMapper.java
@@ -415,8 +415,8 @@ public class TransmitterMapper extends AbstractMapper
 		// EntityIdentifier
 		if( map.containsKey(entityIdentifier.getHandle()) )
 		{
-    		ByteWrapper wrapper = new ByteWrapper( map.get(entityIdentifier.getHandle()) );
-    		object.getEntityIdentifier().decode( wrapper );
+			ByteWrapper wrapper = new ByteWrapper( map.get(entityIdentifier.getHandle()) );
+			object.getEntityIdentifier().decode( wrapper );
 		}
 		
 		// HostObjectIdentifier

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/model/FomHelpers.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/model/FomHelpers.java
@@ -29,6 +29,7 @@ import hla.rti1516e.AttributeHandleSet;
 import hla.rti1516e.InteractionClassHandle;
 import hla.rti1516e.ObjectClassHandle;
 import hla.rti1516e.RTIambassador;
+import hla.rti1516e.exceptions.NameNotFound;
 import hla.rti1516e.exceptions.RTIexception;
 
 /**
@@ -336,7 +337,21 @@ public class FomHelpers
 		
 		// get the attribute handles
 		for( AttributeClass attribute : objectClass.getDeclaredAttributes() )
-			attribute.setHandle( rtiamb.getAttributeHandle(ocHandle,attribute.getName()) );
+		{
+			try
+			{
+				attribute.setHandle( rtiamb.getAttributeHandle(ocHandle,attribute.getName()) );
+			}
+			catch( NameNotFound e )
+			{
+				// if the rti is throwing an error about not finding HLAObjectRoot attributes
+				// its probably Mak, so safe to ignore
+				if ( objectClass.getQualifiedName().equals("HLAobjectRoot") )
+					break;
+				else
+					throw e;
+			}
+		}
 		
 		// recurse for each child
 		for( ObjectClass child : objectClass.getChildren() )
@@ -397,7 +412,12 @@ public class FomHelpers
 		// Turn the attributes into a handle set
 		AttributeHandleSet ahs = rtiamb.getAttributeHandleSetFactory().create();
 		for( AttributeClass attribute : attributes )
+		{
+			if(attribute.getHandle() == null )
+				continue;
+			
 			ahs.add( attribute.getHandle() );
+		}
 
 		//
 		// Publish

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/types/array/RPRlengthlessArray.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/types/array/RPRlengthlessArray.java
@@ -21,6 +21,8 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.openlvc.disco.connection.rpr.types.basic.HLAfloat32BE;
+
 import hla.rti1516e.encoding.ByteWrapper;
 import hla.rti1516e.encoding.DataElement;
 import hla.rti1516e.encoding.DataElementFactory;
@@ -159,6 +161,10 @@ public class RPRlengthlessArray<T extends DataElement> implements DataElement, I
 				element = items.get(count);
 			else
 				element = createElement();
+			
+			// not sure why this occurs, but it should be a HLAoctect, which gets handled elsewhere
+			if ( element instanceof HLAfloat32BE && buffer.remaining() == 1 )
+				break;
 			
 			// Decode into the element
 			element.decode( buffer );

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/types/basic/HLAfloat32BE.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/types/basic/HLAfloat32BE.java
@@ -101,7 +101,16 @@ public class HLAfloat32BE implements hla.rti1516e.encoding.HLAfloat32BE
 	@Override
 	public final void decode( ByteWrapper byteWrapper ) throws DecoderException
 	{
+		if( byteWrapper.remaining() < this.getEncodedLength() )
+			throw new DecoderException( "Insufficient space remaining in buffer to decode this value" );
+		
 		byteWrapper.align( 4 );
+
+		if ( (byteWrapper.remaining() % 4) != 0)
+		{
+			value = 0;
+			return;
+		}
 		value = Float.intBitsToFloat( byteWrapper.getInt() );
 	}
 

--- a/codebase/src/java/disco/org/openlvc/disrespector/Configuration.java
+++ b/codebase/src/java/disco/org/openlvc/disrespector/Configuration.java
@@ -458,7 +458,7 @@ public class Configuration
 		System.out.println( "  --dis-log-file        string   (optional)  Set log file for DIS side only             (default: logs/disrespector.dis.log)" );
 		System.out.println( "" );
 		System.out.println( "HLA Network Settings" );
-		System.out.println( "  --hla-rti-provider    string   (optional)  Portico or Pitch                           (default: Portico)" );
+		System.out.println( "  --hla-rti-provider    string   (optional)  Portico, Pitch or Mak                      (default: Portico)" );
 		System.out.println( "  --hla-rti-dir         string   (optional)  Directory where RTI is installed           (default: RTI Specific)" );
 		System.out.println( "  --hla-local-settings  string   (optional)  Setting string given to RTI on connection" );
 		System.out.println( "  --hla-federation      string   (optional)  Name of federation to join                 (default: disrespector)" );

--- a/codebase/src/java/disco/org/openlvc/duplicator/Configuration.java
+++ b/codebase/src/java/disco/org/openlvc/duplicator/Configuration.java
@@ -502,7 +502,7 @@ public class Configuration
 		builder.append( "   --hla                           If set, HLA will be used rather than DIS\n" );
 		builder.append( "   --hla-federate        (string)  Name of federate                     (default:Duplicator)\n" );
 		builder.append( "   --hla-federation      (string)  Name of federation to join           (default:Disco)\n" );
-		builder.append( "   --hla-rti-provider    (string)  RTI Vendor [Portico|Pitch]           (default:Portico)\n" );
+		builder.append( "   --hla-rti-provider    (string)  RTI Vendor [Portico|Pitch|Mak]       (default:Portico)\n" );
 		builder.append( "   --hla-rti-installdir     (dir)  Directory where RTI is installed     (default:./) \n" );
 		builder.append( "                                   Checks RTI_HOME env-var if not set.\n" );
 		builder.append( "   --hla-create-federation         If set, try to create federation     (default:true)\n" );


### PR DESCRIPTION
Mak RTI 4.4 can now be selected as an option for HLA networking
in both CNR-Sim and CNR-Touch in the same manner Pitch or Portico
can be used.

Mak required several work-arounds due to being C based rather than
Java based.
- module files located in a jar need to be extracted to a regular file.
- Mak's dependencies had to be added to the library path rather than the classpath

Working CNR-1963