### PR TITLE
Fixes EmitterBeams not being removed from EmitterSystems

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/application/EmitterStore.java
+++ b/codebase/src/java/disco/org/openlvc/disco/application/EmitterStore.java
@@ -101,6 +101,10 @@ public class EmitterStore implements IDeleteReaperManaged
 			existing.setLastUpdatedTime( incoming.getLastUpdatedTime() );
 			existing.setLocation( incoming.getLocation() );
 			existing.setSystemType( incoming.getSystemType() );
+
+			// Remove any Beams we have first.
+			// If the pdu does not contain any, they should be deleted...
+			existing.getBeams().clear();
 			
 			// Update the beams - either adding them or replacing them
 			for( EmitterBeam beam : incoming.getBeams() )


### PR DESCRIPTION
Emitter Beams were never removed from Emitter Systems.

The previous implementation would never remove EmitterBeams from a system, even if they were removed from the system.
Now Beams are removed if they a no longer present in the EmitterSystem PDU.

This update will ensure that if a Emitter System no longer has Beams that this change is reflected in the Emitter System store in Disco.