### PR TITLE
Fix the encoding type for spread sprectrum

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/model/FomHelpers.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/model/FomHelpers.java
@@ -344,10 +344,13 @@ public class FomHelpers
 			}
 			catch( NameNotFound e )
 			{
-				// if the rti is throwing an error about not finding HLAObjectRoot attributes
-				// its probably Mak, so safe to ignore
-				if ( objectClass.getQualifiedName().equals("HLAobjectRoot") )
+				// if the rti is throwing an error about not finding the privilege to delete
+				// attribute, it may be using a slightly different name for it
+				if ( attribute.getName().equals("HLAprivilegeToDelete") )
+				{
+					attribute.setHandle( rtiamb.getAttributeHandle(ocHandle,"HLAprivilegeToDeleteObject") );
 					break;
+				}
 				else
 					throw e;
 			}

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/types/variant/SpreadSpectrumVariantStruct.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/types/variant/SpreadSpectrumVariantStruct.java
@@ -17,7 +17,7 @@
  */
 package org.openlvc.disco.connection.rpr.types.variant;
 
-import org.openlvc.disco.connection.rpr.types.basic.HLAinteger32BE;
+import org.openlvc.disco.connection.rpr.types.basic.RPRunsignedInteger16BE;
 import org.openlvc.disco.connection.rpr.types.enumerated.SpreadSpectrumEnum16;
 import org.openlvc.disco.connection.rpr.types.fixed.SINCGARSModulationStruct;
 import org.openlvc.disco.pdu.field.SpreadSpectrum;
@@ -39,9 +39,11 @@ public class SpreadSpectrumVariantStruct extends WrappedHlaVariantRecord<SpreadS
 	{
 		super( SpreadSpectrumEnum16.None );
 		
-		super.setVariant( SpreadSpectrumEnum16.None,                    new HLAinteger32BE()/*dummy*/ );
+		super.setVariant( SpreadSpectrumEnum16.None,                    new RPRunsignedInteger16BE()/*dummy*/ );
 		super.setVariant( SpreadSpectrumEnum16.SINCGARSFrequencyHop,    new SINCGARSModulationStruct() );
-		super.setVariant( SpreadSpectrumEnum16.JTIDS_MIDS_SpectrumType, new HLAinteger32BE()/*dummy*/ );
+		super.setVariant( SpreadSpectrumEnum16.JTIDS_MIDS_SpectrumType, new RPRunsignedInteger16BE()/*dummy*/ );
+		
+		super.setDiscriminant( SpreadSpectrumEnum16.None );
 	}
 	//----------------------------------------------------------
 	//                    INSTANCE METHODS
@@ -62,6 +64,14 @@ public class SpreadSpectrumVariantStruct extends WrappedHlaVariantRecord<SpreadS
 	////////////////////////////////////////////////////////////////////////////////////////////
 	public void setValue( SpreadSpectrum spreadSpectrum )
 	{
+		if( spreadSpectrum.isFrequencyHopping() )
+		{
+			super.setDiscriminant( SpreadSpectrumEnum16.SINCGARSFrequencyHop );
+		}
+		else
+		{
+			super.setDiscriminant( SpreadSpectrumEnum16.None );
+		}
 	}
 
 	public void setSINCGARSModulation()


### PR DESCRIPTION
According to the FOM, the spread spectrum enum should use
a uint16 value for the None value, but it was using an int32 instead,
which was causing decoder exceptions for some objects.
The None value is now using a uint16 to match the FOM, and the
discriminant type gets set based on frequency hopping.

Also a small fix for Mak rti using a modified name for privilege
to delete

Fixes: CNR-2020