### PR TITLE
Fix decoding error in SpreadSpectrum

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/types/basic/Empty.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/types/basic/Empty.java
@@ -1,0 +1,92 @@
+/*
+ *   Copyright 2022 Open LVC Project.
+ *
+ *   This file is part of Open LVC Disco.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.openlvc.disco.connection.rpr.types.basic;
+
+import hla.rti1516e.encoding.ByteWrapper;
+import hla.rti1516e.encoding.DataElement;
+import hla.rti1516e.encoding.DecoderException;
+import hla.rti1516e.encoding.EncoderException;
+
+/**
+ * A dummy class for when a no-value object is needed, e.g. in an HLAVariantStruct
+ * with an empty alternative
+ */
+public class Empty implements DataElement
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public Empty()
+	{
+	}
+	
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	/////////////////////////////////////////////////////////////////////////////////////////
+	/// DataElement Methods /////////////////////////////////////////////////////////////////
+	/////////////////////////////////////////////////////////////////////////////////////////
+	@Override
+	public int getOctetBoundary()
+	{
+		return 0;
+	}
+
+	@Override
+	public void encode( ByteWrapper byteWrapper ) throws EncoderException
+	{
+		// No-op
+	}
+
+	@Override
+	public int getEncodedLength()
+	{
+		return 0;
+	}
+
+	@Override
+	public byte[] toByteArray() throws EncoderException
+	{
+		return new byte[0];
+	}
+
+	@Override
+	public void decode( ByteWrapper byteWrapper ) throws DecoderException
+	{
+		// No-op
+	}
+
+	@Override
+	public void decode( byte[] bytes ) throws DecoderException
+	{
+		// No-op
+	}
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/types/variant/SpreadSpectrumVariantStruct.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/types/variant/SpreadSpectrumVariantStruct.java
@@ -17,6 +17,7 @@
  */
 package org.openlvc.disco.connection.rpr.types.variant;
 
+import org.openlvc.disco.connection.rpr.types.basic.Empty;
 import org.openlvc.disco.connection.rpr.types.basic.RPRunsignedInteger16BE;
 import org.openlvc.disco.connection.rpr.types.enumerated.SpreadSpectrumEnum16;
 import org.openlvc.disco.connection.rpr.types.fixed.SINCGARSModulationStruct;
@@ -39,7 +40,7 @@ public class SpreadSpectrumVariantStruct extends WrappedHlaVariantRecord<SpreadS
 	{
 		super( SpreadSpectrumEnum16.None );
 		
-		super.setVariant( SpreadSpectrumEnum16.None,                    new RPRunsignedInteger16BE()/*dummy*/ );
+		super.setVariant( SpreadSpectrumEnum16.None,                    new Empty()/*dummy*/ );
 		super.setVariant( SpreadSpectrumEnum16.SINCGARSFrequencyHop,    new SINCGARSModulationStruct() );
 		super.setVariant( SpreadSpectrumEnum16.JTIDS_MIDS_SpectrumType, new RPRunsignedInteger16BE()/*dummy*/ );
 		


### PR DESCRIPTION
SpreadSpectrum had been using a uint16 as a dummy value
for the None alternative, but as there is no value for None
it would fail to decode. Now it uses an empty value, so it
will be able to encode/decode successfully

Fixes: CNR-2020