### PR TITLE
Add the other weather domain types

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/custom/dcss/types/enumerated/CloudClassification.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/custom/dcss/types/enumerated/CloudClassification.java
@@ -1,0 +1,125 @@
+/*
+ *   Copyright 2020 Open LVC Project.
+ *
+ *   This file is part of Open LVC Disco.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.openlvc.disco.connection.rpr.custom.dcss.types.enumerated;
+
+import org.openlvc.disco.connection.rpr.types.basic.HLAoctet;
+import org.openlvc.disco.connection.rpr.types.enumerated.ExtendedDataElement;
+
+import hla.rti1516e.encoding.ByteWrapper;
+import hla.rti1516e.encoding.DecoderException;
+import hla.rti1516e.encoding.EncoderException;
+
+public enum CloudClassification implements ExtendedDataElement<CloudClassification>
+{
+	//----------------------------------------------------------
+	//                        VALUES
+	//----------------------------------------------------------
+	InvalidCloudClassification( new HLAoctet(0) ),
+	NoCloud( new HLAoctet(1) ),
+	Cirrus( new HLAoctet(2) ),
+	Cirrocumulus( new HLAoctet(3) ),
+	Cirrostratus( new HLAoctet(4) ),
+	Altocumulus( new HLAoctet(5) ),
+	Altostratus( new HLAoctet(6) ),
+	Stratocumulus( new HLAoctet(7) ),
+	Nimbostratus( new HLAoctet(8) ),
+	Cumulus( new HLAoctet(9) ),
+	Stratus( new HLAoctet(10) ),
+	CumulusCongestus( new HLAoctet(11) ),
+	Cumulonimbus( new HLAoctet(12) ),
+	Unknown( new HLAoctet(13) );
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private HLAoctet value;
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	private CloudClassification( HLAoctet value )
+	{
+		this.value = value;
+	}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	public byte getValue()
+	{
+		return this.value.getValue();
+	}
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/// Data Element Methods   /////////////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	@Override
+	public int getOctetBoundary()
+	{
+		return value.getOctetBoundary();
+	}
+
+	@Override
+	public void encode( ByteWrapper byteWrapper ) throws EncoderException
+	{
+		value.encode( byteWrapper );
+	}
+
+
+	@Override
+	public int getEncodedLength()
+	{
+		return value.getEncodedLength();
+	}
+
+
+	@Override
+	public byte[] toByteArray() throws EncoderException
+	{
+		return value.toByteArray();
+	}
+
+
+	@Override
+	public CloudClassification valueOf( ByteWrapper value ) throws DecoderException
+	{
+		HLAoctet temp = new HLAoctet();
+		temp.decode( value );
+		return valueOf( temp.getValue() );
+	}
+
+	@Override
+	public CloudClassification valueOf( byte[] value ) throws DecoderException
+	{
+		HLAoctet temp = new HLAoctet();
+		temp.decode( value );
+		return valueOf( temp.getValue() );
+	}
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	public static CloudClassification valueOf( byte value )
+	{
+		for( CloudClassification temp : CloudClassification.values() )
+			if( temp.value.getValue() == value )
+				return temp;
+		
+		throw new IllegalArgumentException( "Unknown enumerator value: "+value+" (CloudClassification)" );
+	}
+}

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/custom/dcss/types/fixed/AtmosphereResponseData.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/custom/dcss/types/fixed/AtmosphereResponseData.java
@@ -1,0 +1,63 @@
+package org.openlvc.disco.connection.rpr.custom.dcss.types.fixed;
+
+import org.openlvc.disco.connection.rpr.types.basic.HLAfloat32BE;
+import org.openlvc.disco.connection.rpr.types.fixed.WrappedHlaFixedRecord;
+
+public class AtmosphereResponseData extends WrappedHlaFixedRecord
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private HLAfloat32BE temperature;
+	private HLAfloat32BE pressure;
+	private HLAfloat32BE mslPressure;
+	private HLAfloat32BE windDirection;
+	private HLAfloat32BE windSpeed;
+	private HLAfloat32BE humidity;
+	private HLAfloat32BE verticalWind;
+	
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public AtmosphereResponseData()
+	{
+		this.temperature = new HLAfloat32BE();
+		this.pressure = new HLAfloat32BE();
+		this.mslPressure = new HLAfloat32BE();
+		this.windDirection = new HLAfloat32BE();
+		this.windSpeed = new HLAfloat32BE();
+		this.humidity = new HLAfloat32BE();
+		this.verticalWind = new HLAfloat32BE();
+		
+		this.add( this.temperature,
+		          this.pressure,
+		          this.mslPressure,
+		          this.windDirection,
+		          this.windSpeed,
+		          this.humidity,
+		          this.verticalWind );
+	}
+	
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/// Accessor and Mutator Methods   /////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	public HLAfloat32BE getTemperature() { return this.temperature; }
+	public HLAfloat32BE getPressure() { return this.pressure; }
+	public HLAfloat32BE getMslPressure() { return this.mslPressure; }
+	public HLAfloat32BE getWindDirection() { return this.windDirection; }
+	public HLAfloat32BE getWindSpeed() { return this.windSpeed; }
+	public HLAfloat32BE getHumidity() { return this.humidity; }
+	public HLAfloat32BE getVerticalWind() { return this.verticalWind; }
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/custom/dcss/types/fixed/CloudLayer.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/custom/dcss/types/fixed/CloudLayer.java
@@ -1,0 +1,53 @@
+package org.openlvc.disco.connection.rpr.custom.dcss.types.fixed;
+
+import org.openlvc.disco.connection.rpr.custom.dcss.types.enumerated.CloudClassification;
+import org.openlvc.disco.connection.rpr.types.basic.HLAfloat32BE;
+import org.openlvc.disco.connection.rpr.types.enumerated.EnumHolder;
+import org.openlvc.disco.connection.rpr.types.fixed.WrappedHlaFixedRecord;
+
+public class CloudLayer extends WrappedHlaFixedRecord
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private HLAfloat32BE top;
+	private HLAfloat32BE base;
+	private HLAfloat32BE coverage;
+	private EnumHolder<CloudClassification> type;
+	
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public CloudLayer()
+	{
+		this.top = new HLAfloat32BE();
+		this.base = new HLAfloat32BE();
+		this.coverage = new HLAfloat32BE();
+		this.type = new EnumHolder<>( CloudClassification.InvalidCloudClassification );
+		
+		this.add( this.top,
+		          this.base,
+		          this.coverage,
+		          this.type );
+	}
+	
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/// Accessor and Mutator Methods   /////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	public HLAfloat32BE getTop() { return this.top; }
+	public HLAfloat32BE getBase() { return this.base; }
+	public HLAfloat32BE getCoverage() { return this.coverage; }
+	public EnumHolder<CloudClassification> getType() { return this.type; }
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/custom/dcss/types/fixed/CloudResponseData.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/custom/dcss/types/fixed/CloudResponseData.java
@@ -1,0 +1,74 @@
+package org.openlvc.disco.connection.rpr.custom.dcss.types.fixed;
+
+import org.openlvc.disco.connection.rpr.custom.dcss.types.enumerated.PrecipitationType;
+import org.openlvc.disco.connection.rpr.types.basic.HLAfloat32BE;
+import org.openlvc.disco.connection.rpr.types.enumerated.EnumHolder;
+import org.openlvc.disco.connection.rpr.types.fixed.WrappedHlaFixedRecord;
+
+public class CloudResponseData extends WrappedHlaFixedRecord
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private HLAfloat32BE totalCloudCover;
+	private CloudLayer highCloud;
+	private CloudLayer midCloud;
+	private CloudLayer lowCloud;
+	private CloudLayer convecCloud;
+	private HLAfloat32BE precipitationRate;
+	private HLAfloat32BE convecPrecipitationRate;
+	private EnumHolder<PrecipitationType> precipitationType;
+	private HLAfloat32BE lightning;
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public CloudResponseData()
+	{
+		this.totalCloudCover = new HLAfloat32BE();
+		this.highCloud = new CloudLayer();
+		this.midCloud = new CloudLayer();
+		this.lowCloud = new CloudLayer();
+		this.convecCloud = new CloudLayer();
+		this.precipitationRate = new HLAfloat32BE();
+		this.convecPrecipitationRate = new HLAfloat32BE();
+		this.precipitationType = new EnumHolder<>( PrecipitationType.InvalidPrecipitationType );
+		this.lightning = new HLAfloat32BE();
+		
+		this.add( this.totalCloudCover,
+		          this.highCloud,
+		          this.midCloud,
+		          this.lowCloud,
+		          this.convecCloud,
+		          this.precipitationRate,
+		          this.convecPrecipitationRate,
+		          this.precipitationType,
+		          this.lightning );
+	}
+	
+	
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/// Accessor and Mutator Methods   /////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	public HLAfloat32BE getTotalCloudCover() { return this.totalCloudCover; }
+	public CloudLayer getHighCloud() { return this.highCloud; }
+	public CloudLayer getMidCloud() { return this.midCloud; }
+	public CloudLayer getLowCloud() { return this.lowCloud; }
+	public CloudLayer getConvecCloud() { return this.convecCloud; }
+	public HLAfloat32BE getPrecipitationRate() { return this.precipitationRate; }
+	public HLAfloat32BE getConvecPrecipitationRate() { return this.convecPrecipitationRate; }
+	public EnumHolder<PrecipitationType> getPrecipitationType() { return this.precipitationType; }
+	public HLAfloat32BE getLightning() { return this.lightning; }
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/custom/dcss/types/fixed/SubsurfaceResponseData.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/custom/dcss/types/fixed/SubsurfaceResponseData.java
@@ -1,0 +1,52 @@
+package org.openlvc.disco.connection.rpr.custom.dcss.types.fixed;
+
+import org.openlvc.disco.connection.rpr.types.basic.HLAfloat32BE;
+import org.openlvc.disco.connection.rpr.types.fixed.WrappedHlaFixedRecord;
+
+public class SubsurfaceResponseData extends WrappedHlaFixedRecord
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private HLAfloat32BE temperature;
+	private HLAfloat32BE salinity;
+	private HLAfloat32BE currentSpeed;
+	private HLAfloat32BE currentDirection;
+	
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public SubsurfaceResponseData()
+	{
+		this.temperature = new HLAfloat32BE();
+		this.salinity = new HLAfloat32BE();
+		this.currentSpeed = new HLAfloat32BE();
+		this.currentDirection = new HLAfloat32BE();
+		
+		this.add( this.temperature,
+		          this.salinity,
+		          this.currentSpeed,
+		          this.currentDirection );
+	}
+	
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/// Accessor and Mutator Methods   /////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	
+	public HLAfloat32BE getTemperature() { return this.temperature; }
+	public HLAfloat32BE getSalinity() { return this.salinity; }
+	public HLAfloat32BE getCurrentSpeed() { return this.currentSpeed; }
+	public HLAfloat32BE getCurrentDirection() { return this.currentDirection; }
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/custom/dcss/types/fixed/SurfaceResponseData.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/custom/dcss/types/fixed/SurfaceResponseData.java
@@ -1,0 +1,75 @@
+package org.openlvc.disco.connection.rpr.custom.dcss.types.fixed;
+
+import org.openlvc.disco.connection.rpr.types.basic.HLAfloat32BE;
+import org.openlvc.disco.connection.rpr.types.fixed.WrappedHlaFixedRecord;
+
+public class SurfaceResponseData extends WrappedHlaFixedRecord
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private HLAfloat32BE windDirection;
+	private HLAfloat32BE windSpeed;
+	private HLAfloat32BE totalWaveHeight;
+	private HLAfloat32BE windWaveHeight;
+	private HLAfloat32BE windWavePeriod;
+	private HLAfloat32BE windWaveDirection;
+	private HLAfloat32BE primaryWavePeriod;
+	private HLAfloat32BE primaryWaveDirection;
+	private HLAfloat32BE swellHeight;
+	private HLAfloat32BE swellDirection;
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public SurfaceResponseData()
+	{
+		this.windDirection = new HLAfloat32BE();
+		this.windSpeed = new HLAfloat32BE();
+		this.totalWaveHeight = new HLAfloat32BE();
+		this.windWaveHeight = new HLAfloat32BE();
+		this.windWavePeriod = new HLAfloat32BE();
+		this.windWaveDirection = new HLAfloat32BE();
+		this.primaryWavePeriod = new HLAfloat32BE();
+		this.primaryWaveDirection = new HLAfloat32BE();
+		this.swellHeight = new HLAfloat32BE();
+		this.swellDirection = new HLAfloat32BE();
+		
+		this.add( this.windDirection,
+		          this.windSpeed,
+		          this.totalWaveHeight,
+		          this.windWaveHeight,
+		          this.windWavePeriod,
+		          this.windWaveDirection,
+		          this.primaryWavePeriod,
+		          this.primaryWaveDirection,
+		          this.swellHeight,
+		          this.swellDirection );
+	}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	////////////////////////////////////////////////////////////////////////////////////////////
+	/// Accessor and Mutator Methods   /////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////////
+	public HLAfloat32BE getWindDirection() { return this.windDirection; }
+	public HLAfloat32BE getWindSpeed() { return this.windSpeed; }
+	public HLAfloat32BE getTotalWaveHeight() { return this.totalWaveHeight; }
+	public HLAfloat32BE getWindWaveHeight() { return this.windWaveHeight; }
+	public HLAfloat32BE getWindWavePeriod() { return this.windWavePeriod; }
+	public HLAfloat32BE getWindWaveDirection() { return this.windWaveDirection; }
+	public HLAfloat32BE getPrimaryWavePeriod() { return this.primaryWaveDirection; }
+	public HLAfloat32BE getPrimaryWaveDirection() { return this.primaryWaveDirection; }
+	public HLAfloat32BE getSwellHeight() { return this.swellHeight; }
+	public HLAfloat32BE getSwellDirection() { return this.swellDirection; }
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/custom/dcss/types/variant/WeatherResponseDataVariant.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/custom/dcss/types/variant/WeatherResponseDataVariant.java
@@ -18,7 +18,11 @@
 package org.openlvc.disco.connection.rpr.custom.dcss.types.variant;
 
 import org.openlvc.disco.connection.rpr.custom.dcss.types.enumerated.Domain;
+import org.openlvc.disco.connection.rpr.custom.dcss.types.fixed.AtmosphereResponseData;
+import org.openlvc.disco.connection.rpr.custom.dcss.types.fixed.CloudResponseData;
 import org.openlvc.disco.connection.rpr.custom.dcss.types.fixed.GroundResponseData;
+import org.openlvc.disco.connection.rpr.custom.dcss.types.fixed.SubsurfaceResponseData;
+import org.openlvc.disco.connection.rpr.custom.dcss.types.fixed.SurfaceResponseData;
 import org.openlvc.disco.connection.rpr.types.variant.WrappedHlaVariantRecord;
 
 public class WeatherResponseDataVariant extends WrappedHlaVariantRecord<Domain>
@@ -37,11 +41,11 @@ public class WeatherResponseDataVariant extends WrappedHlaVariantRecord<Domain>
 	public WeatherResponseDataVariant()
 	{
 		super( Domain.InvalidDomain );
-		// this.setVariant( Domain.Atmosphere, new AtmosphereResponseData() );
+		this.setVariant( Domain.Atmosphere, new AtmosphereResponseData() );
 		this.setVariant( Domain.Ground, new GroundResponseData() );
-		// this.setVariant( Domain.Cloud, new CloudResponseData() );
-		// this.setVariant( Domain.Surface, new SurfaceResponseData() );
-		// this.setVariant( Domain.Subsurface, new SubsurfaceResponseData() );
+		this.setVariant( Domain.Cloud, new CloudResponseData() );
+		this.setVariant( Domain.Surface, new SurfaceResponseData() );
+		this.setVariant( Domain.Subsurface, new SubsurfaceResponseData() );
 	}
 
 	//----------------------------------------------------------


### PR DESCRIPTION
The only weather domain that had been used was ground,
so the other types were left unimplemented. This implements
the other domains to fix issue reported by BDUK when trying to
use the atmosphere domain.

Fixes: CNR-2023