### PR TITLE
Fix Mak RTI support when RTI provider is changed

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/configuration/RprConfiguration.java
+++ b/codebase/src/java/disco/org/openlvc/disco/configuration/RprConfiguration.java
@@ -99,6 +99,8 @@ public class RprConfiguration
 	// FOM-specific values. Careful to manage with DIS properties so they don't ignore each other
 	private List<URL> fomModules;
 	private List<AbstractMapper> fomMappers;
+	
+	private List<String> extensionModules;
 
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
@@ -109,6 +111,8 @@ public class RprConfiguration
 		
 		this.fomModules = new ArrayList<>();
 		this.fomMappers = new ArrayList<>();
+		
+		this.extensionModules = new ArrayList<>();
 	}
 
 	//----------------------------------------------------------
@@ -175,6 +179,17 @@ public class RprConfiguration
 	public void setRtiProvider( RtiProvider provider )
 	{
 		parent.setProperty( PROP_RTI_PROVIDER, provider.name() );
+		
+		// Mak is picky, best to clear and reload the FOMs - now that Mak is set
+		// they will be extracted out from the jar so it can load them
+		if( provider == RtiProvider.Mak )
+		{
+			this.fomModules.clear();
+			loadDefaultModules();
+			
+			// re-add extension modules
+			registerExtensionModules( this.extensionModules.toArray(new String[0]) );
+		}
 	}
 	
 	public void setRtiProvider( String provider )
@@ -450,6 +465,12 @@ public class RprConfiguration
 				else
 					// can't find it!
 					throw new DiscoException( "Cannot find extension module: "+path );
+			}
+			
+			//keeping track of these helps if at some point we switch to using Mak
+			if( !this.extensionModules.contains(path) )
+			{
+				this.extensionModules.add( path );
 			}
 		}
 	}

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/RprConnection.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/RprConnection.java
@@ -424,10 +424,15 @@ public class RprConnection implements IConnection
 	 */
 	private void cleanupFederation()
 	{
+		if( this.rtiamb == null )
+		{
+			return;
+		}
+		
 		try
 		{
 			// Resign from the federation
-    		this.rtiamb.resignFederationExecution( ResignAction.DELETE_OBJECTS_THEN_DIVEST );
+			this.rtiamb.resignFederationExecution( ResignAction.DELETE_OBJECTS_THEN_DIVEST );
 		}
 		catch( RTIexception rtie )
 		{


### PR DESCRIPTION
Previously if the RTI provider was set to Mak after FOM moudles had
been initialised, it would cause errors due to the needed FOM files
not being extracted out of the jar, which Mak requires. Now a check
is done when the RTI provider is changed to Mak to make sure it can
load all of the FOM files.

Also fixes an NPE on federation cleanup if an RTI fails to start

Fixes: CNR-2026