### PR TITLE
Fix NPE when stop called on non-started connection

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/application/DeleteReaper.java
+++ b/codebase/src/java/disco/org/openlvc/disco/application/DeleteReaper.java
@@ -66,6 +66,11 @@ public class DeleteReaper implements Runnable
 	
 	public void stop()
 	{
+		if( this.thread == null )
+		{
+			return;
+		}
+		
 		this.thread.interrupt();
 		try
 		{

--- a/codebase/src/java/disco/org/openlvc/disco/application/Heartbeater.java
+++ b/codebase/src/java/disco/org/openlvc/disco/application/Heartbeater.java
@@ -90,6 +90,11 @@ public class Heartbeater implements Runnable
 	
 	public void stop()
 	{
+		if( this.thread == null )
+		{
+			return;
+		}
+		
 		this.thread.interrupt();
 		try
 		{


### PR DESCRIPTION
If stop was called on a rpr connection that hadn't been started yet,
e.g. because start had previously failed, then a null pointer exception
was thrown. A null check is now made on shutdown to prevent this.

Fixes: CNR-2032