### PR TITLE
Add check for EmitterBeam length > 255 to be compliant with DIS 7 spec.

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/pdu/emissions/EmitterBeam.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/emissions/EmitterBeam.java
@@ -137,6 +137,13 @@ public class EmitterBeam implements IPduComponent, Cloneable
 	@Override
     public void to( DisOutputStream dos ) throws IOException
     {
+		// ref DIS-7 spec section 7.6.2 paragraph f.5.i
+		// if length exceeds 255 this value is not used and should be set to 0
+		
+		int beamLength = getByteLength();
+		if( beamLength > 255 )
+			beamLength = 0;
+
 		dos.writeUI8( (short)getByteLength() );
 		dos.writeUI8( beamNumber );
 		dos.writeUI16( parameterIndex );


### PR DESCRIPTION
DIS 7 Spec (7.6.2 paragraph f.5.i) says that for an emitter beam, if the length of the beam is greater than 255, write it as 0.

I checked that the length for this record isn't being used anywhere in deserialization (we go by the number of records, which is also written to the record in the PDU), so this shouldn't have an advserse impact.