### PR TITLE
(UPDATED) Add check for EmitterBeam length > 255 to be compliant with DIS 7 spec

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/pdu/emissions/EmitterBeam.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/emissions/EmitterBeam.java
@@ -137,6 +137,13 @@ public class EmitterBeam implements IPduComponent, Cloneable
 	@Override
     public void to( DisOutputStream dos ) throws IOException
     {
+		// ref DIS-7 spec section 7.6.2 paragraph f.5.i
+		// if length exceeds 255 this value is not used and should be set to 0
+		
+		int beamLength = getByteLength();
+		if( beamLength > 255 )
+			beamLength = 0;
+
 		dos.writeUI8( (short)getByteLength() );
 		dos.writeUI8( beamNumber );
 		dos.writeUI16( parameterIndex );

--- a/codebase/src/java/disco/org/openlvc/disco/pdu/emissions/EmitterBeam.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/emissions/EmitterBeam.java
@@ -140,7 +140,7 @@ public class EmitterBeam implements IPduComponent, Cloneable
 		// ref DIS-7 spec section 7.6.2 paragraph f.5.i
 		// if length exceeds 255 this value is not used and should be set to 0
 		
-		int beamLength = getByteLength();
+		int beamLength = getByteLength() / 4;  // Count in 32-bit words
 		if( beamLength > 255 )
 			beamLength = 0;
 

--- a/codebase/src/java/disco/org/openlvc/disco/pdu/emissions/EmitterSystem.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/emissions/EmitterSystem.java
@@ -107,7 +107,7 @@ public class EmitterSystem implements IPduComponent, Cloneable
 	{
 		// ref DIS-7 spec section 7.6.2 paragraph f.1
 		// if length exceeds 255 this value is not used and should be set to 0
-		short length = (short) getByteLength();
+		short length = (short)(getByteLength() / 4);  // 32-bit words
 		if( length > 255 )
 		{
 			length = 0;


### PR DESCRIPTION
Added updates for a shortcoming that @michaelrfraser identified as part of PR #59. 

`Emitter Beam Length` and `Emitter System Length` are both now encoded as the number of _32-bit words_ (not the number of 8-bit words).