### PR TITLE
Update logging to stop overriding jvm-wide config

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/configuration/Log4jConfiguration.java
+++ b/codebase/src/java/disco/org/openlvc/disco/configuration/Log4jConfiguration.java
@@ -18,18 +18,21 @@
 package org.openlvc.disco.configuration;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
-import org.apache.logging.log4j.core.config.Configurator;
-import org.apache.logging.log4j.core.config.builder.api.AppenderComponentBuilder;
-import org.apache.logging.log4j.core.config.builder.api.ComponentBuilder;
-import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
-import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
-import org.apache.logging.log4j.core.config.builder.api.LayoutComponentBuilder;
-import org.apache.logging.log4j.core.config.builder.api.RootLoggerComponentBuilder;
-import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.apache.logging.log4j.core.appender.FileAppender;
+import org.apache.logging.log4j.core.appender.RollingFileAppender;
+import org.apache.logging.log4j.core.appender.rolling.SizeBasedTriggeringPolicy;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.layout.PatternLayout;
 
 /**
  * Allows a user to define the basic properties for a Log4j configuration and then tell it
@@ -52,6 +55,7 @@ public class Log4jConfiguration
 	private boolean consoleOn;
 	private boolean fileOn;
 	private File file;
+	private Set<Appender> additionalAppenders;
 
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
@@ -66,7 +70,8 @@ public class Log4jConfiguration
 		this.level = Level.INFO;
 		this.consoleOn = true;
 		this.fileOn = true;
-		this.file = new File( "logs/bts.log" );
+		this.file = new File( "logs/disco.log" );
+		this.additionalAppenders = new HashSet<>();
 	}
 
 	//----------------------------------------------------------
@@ -76,91 +81,118 @@ public class Log4jConfiguration
 	////////////////////////////////////////////////////////////////////////////////////////////
 	/// Configuration Activation Methods    ////////////////////////////////////////////////////
 	////////////////////////////////////////////////////////////////////////////////////////////
-	
-	private void attachConsoleAppender( ConfigurationBuilder<BuiltConfiguration> rootBuilder,
-	                                    RootLoggerComponentBuilder rootLogger )
-	{
-		AppenderComponentBuilder appender = rootBuilder.newAppender( "Console", "CONSOLE" );
-		appender.addAttribute( "target", ConsoleAppender.Target.SYSTEM_OUT );
-		appender.add( getLayout(rootBuilder) );
-		rootLogger.add( rootBuilder.newAppenderRef("Console") );
-		rootBuilder.add( appender );
-	}
-
-	private void attachFileAppender( ConfigurationBuilder<BuiltConfiguration> rootBuilder,
-	                                 RootLoggerComponentBuilder rootLogger )
-	{
-		// create the appender builder - arguments are (name, type) where type is a magic string
-		// that references a file-type appender
-		AppenderComponentBuilder appender = rootBuilder.newAppender( "File", "File" );
-		appender.addAttribute( "fileName", file.getAbsolutePath() )
-		        .addAttribute( "append", false )
-		        .addAttribute( "ignoreExceptions", false )
-		        .addAttribute( "bufferedIo", true )
-		        .addAttribute( "bufferSize", 8192 )
-		        .add( getLayout(rootBuilder) );
-		
-		rootLogger.add( rootBuilder.newAppenderRef("File") );
-		rootBuilder.add( appender );
-	}
-
-	@SuppressWarnings("unused")
-	private void attachRollingFileAppender( ConfigurationBuilder<BuiltConfiguration> rootBuilder,
-	                                        RootLoggerComponentBuilder rootLogger )
-	{
-		// create a rollover trigger
-		@SuppressWarnings("rawtypes")
-		ComponentBuilder rolloverTrigger =
-			rootBuilder.newComponent( "Policies" )
-			           .addComponent( rootBuilder.newComponent("SizeBasedTriggeringPolicy")
-			                                     .addAttribute( "size", "100MB" ) );
-
-		AppenderComponentBuilder appender = rootBuilder.newAppender( "File", "RollingFile" );
-		appender.addAttribute( "fileName", file.getAbsolutePath() )
-		        .addAttribute( "filePattern", file.getName()+"-%d{MM-dd-yy-HH-mm-ss}.log" )
-		        .add( getLayout(rootBuilder) )
-		        .addComponent( rolloverTrigger );
-		
-		rootLogger.add( rootBuilder.newAppenderRef("File") );
-		rootBuilder.add( appender );
-	}
-
-	private LayoutComponentBuilder getLayout( ConfigurationBuilder<BuiltConfiguration> builder )
-	{
-		return builder.newLayout( "PatternLayout" ).addAttribute( "pattern", this.pattern )
-		                                           .addAttribute( "charset", "UTF-8" );
-	}
-	
 	/** Take the configuration values and make them active for the specified root logger */
 	public void activateConfiguration()
 	{
-		// What an absolute pile of trash. This is apparently the way you are meant to build
-		// configurations in code. With a bunch of magic strings pointing at plugins for what
-		// are standard parts of the Log4j core. What enterprise pattern abstract factory crack
-		// were these guys smoking?
+		// create a new config object and get the context (we'll need it later)
+		// once we're done configuring the config we'll add it to the context and then
+		// tell it to refresh itself
+		LoggerConfig config = new LoggerConfig( appName, Level.OFF, true );
+		LoggerContext context = (LoggerContext)LogManager.getContext( false );
 		
-		// Create the main configuration builder
-		ConfigurationBuilder<BuiltConfiguration> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
-		builder.setStatusLevel( Level.OFF );
-		builder.setConfigurationName( appName );
-		
-		// Specify the root logger configuration
-		RootLoggerComponentBuilder rootLogger = builder.newRootLogger( this.level );
-		
-		// Create the appenders and add them
+		// remove any existing appenders
+		Map<String,Appender> appenders = new HashMap<>( config.getAppenders() );
+		for( String key : appenders.keySet() )
+			config.removeAppender( key );
+
+		// create the new appenders and attach them
 		if( this.consoleOn )
-			attachConsoleAppender( builder, rootLogger );
+		{
+			ConsoleAppender appender = createConsoleAppender();
+			appender.start();
+			config.addAppender( appender, level, null );
+		}
 		
 		if( this.fileOn )
-			attachFileAppender( builder, rootLogger );
+		{
+			FileAppender appender = createFileAppender( context );
+			appender.start();
+			config.addAppender( appender, level, null );
+		}
+
+		for( Appender appender : this.additionalAppenders )
+		{
+			appender.start();
+			config.addAppender( appender, level, null );
+		}
 		
-		// Add the root logger and configure
-		builder.add( rootLogger );
-		Configurator.reconfigure( builder.build() );
+		// set the logger level
+		config.setLevel( this.level );
+		
+		// flush the update
+		context.getConfiguration().addLogger( appName, config );
+		context.updateLoggers();
+	}
+
+	/**
+	 * Adds an additional appender to disco's logger.
+	 * <p/>
+	 * By default, Disco provides console and file appenders which are activated according to the 
+	 * configuration within this object. Additional appenders may be added through this method.
+	 * <p/>
+	 * NOTE: Appenders added by this method will not be activated until {@link #activateConfiguration()}
+	 * is called.
+	 * 
+	 * @param appender the appender to add to disco's logger
+	 */
+	public void addAdditionalAppender( Appender appender )
+	{
+		this.additionalAppenders.add( appender );
+	}
+	
+	public void removeAdditionalAppender( Appender appender )
+	{
+		this.additionalAppenders.remove( appender );
+	}
+
+	private ConsoleAppender createConsoleAppender()
+	{
+		PatternLayout layout = PatternLayout.newBuilder().withPattern(this.pattern).build();
+		
+		return ConsoleAppender.newBuilder()
+		                      .setLayout( layout )
+		                      .setTarget( ConsoleAppender.Target.SYSTEM_OUT )
+		                      .setName( appName + "-Console" )
+		                      .setIgnoreExceptions( false )
+		                      .build();
+	}
+	
+	private FileAppender createFileAppender( LoggerContext context )
+	{
+		PatternLayout layout = PatternLayout.newBuilder().withPattern(this.pattern).build();
+		
+		return FileAppender.newBuilder()
+		                   .withFileName( file.getAbsolutePath() )
+		                   .withAppend( false )
+		                   .withLocking(false)
+		                   .setName( appName + "-File" )
+		                   .setImmediateFlush( true )
+		                   .setIgnoreExceptions( false )
+		                   .setBufferedIo( true )
+		                   .setBufferSize( 8192 )
+		                   .setLayout( layout )
+		                   .withAdvertise( false )
+		                   .setConfiguration( context.getConfiguration() )
+		                   .build();
+	}
+	
+	@SuppressWarnings("unused")
+	private RollingFileAppender createRollingFileAppender( )
+	{
+		SizeBasedTriggeringPolicy sizePolicy = SizeBasedTriggeringPolicy.createPolicy( "10MB" );
+		PatternLayout layout = PatternLayout.newBuilder().withPattern(this.pattern).build();
+		
+		return RollingFileAppender.newBuilder()
+		                          .withPolicy( sizePolicy )
+		                          .setName( "RollingFile" )
+		                          .withFileName( file.getAbsolutePath() )
+		                          .withFilePattern( file.getName()+"-%d{MM-dd-yy-HH-mm-ss}.log" )
+		                          .setLayout( layout )
+		                          .build();
 	}
 
 	////////////////////////////////////////////////////////////////////////////////////////////
-	/// Accessor and Mutator Methods ///////////////////////////////////////////////////////////
+	/////////////////////////////// Accessor and Mutator Methods ///////////////////////////////
 	////////////////////////////////////////////////////////////////////////////////////////////
 	/**
 	 * Disable this configuration entirely. Sets the log level to OFF and disables file and


### PR DESCRIPTION
The previous update to logging was causing configuration changes across the jvm. E.g. if configured to warn level, all loggers were being set to warn, not just the DISCO ones. This is now more in line with previous behaviour, but without the deprecated methods.

Fixes: CNR-2127