### PR TITLE
Adds SATCOM as a DIS major modulation type

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/pdu/field/MajorModulationType.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/field/MajorModulationType.java
@@ -33,7 +33,8 @@ public enum MajorModulationType
 	Combination( 4 ),
 	Pulse( 5 ),
 	Unmodulated( 6 ),
-	CPSM( 7 );
+	CPSM( 7 ),
+	SATCOM( 8 );
 
 	//----------------------------------------------------------
 	//                   INSTANCE VARIABLES


### PR DESCRIPTION
SATCOM was added as a major modulation type to the DIS spec, so this adds it as a supported value.

Fixes: CNR-2123