### PR TITLE
Update to disco to be more compliant with FOM module loading

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/configuration/RprConfiguration.java
+++ b/codebase/src/java/disco/org/openlvc/disco/configuration/RprConfiguration.java
@@ -491,7 +491,9 @@ public class RprConfiguration
 			"hla/rpr2/RPR-Enumerations_v2.0.xml",
 			"hla/rpr2/RPR-Physical_v2.0.xml",
 			"hla/rpr2/RPR-SIMAN_v2.0.xml",
-			"hla/rpr2/RPR-Warfare_v2.0.xml"
+			"hla/rpr2/RPR-Warfare_v2.0.xml",
+			"hla/rpr2/RPR-Aggregate_v2.0.xml",
+			"hla/rpr2/RPR-SE_v2.0.xml",
 		};
 		
 		if( getRtiProvider() == RtiProvider.Mak )

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/model/InteractionClass.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/model/InteractionClass.java
@@ -97,8 +97,11 @@ public class InteractionClass
 		// make sure we don't already have one by this name
 		if( parameters.containsKey(parameter.getName()) )
 		{
-			throw new DiscoException( "Add Parameter Failed: Class [%s] already has parameter with name [%s]",
-			                          name, parameter.getName() );
+			// FIXME - we'll assume that this parameter has the same definition - which makes this fine
+			// but if it were defined any differently we should error out.
+			return;
+			// throw new DiscoException( "Add Parameter Failed: Class [%s] already has parameter with name [%s]",
+			                        //   name, parameter.getName() );
 		}
 		
 		// store the parameter


### PR DESCRIPTION
Disco was previously throwing an exception if two FOM modules defined the same parameter for a class. However according to the spec, this is fine, as long as the definition is the same. This now allows duplicate parameters.

NOTE: currently assuming that parameters with the same name ARE the same, which is not necessarily the case.