### PR TITLE
Fixes reporting of Signal PDU fixed part length

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/pdu/field/TdlType.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/field/TdlType.java
@@ -78,7 +78,7 @@ public enum TdlType
 	//----------------------------------------------------------
 	public static final int getByteLength()
 	{
-		return DisSizes.UI8_SIZE;
+		return DisSizes.UI16_SIZE;
 	}
 
 	public static TdlType fromValue( int value )

--- a/codebase/src/java/disco/org/openlvc/disco/pdu/radio/SignalPdu.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/radio/SignalPdu.java
@@ -114,13 +114,13 @@ public class SignalPdu extends PDU
 	@Override
 	public final int getContentLength()
 	{
-		return 19 + data.length;
+		return 20 + data.length;
 		
 		// int size = entityID.getByteLength();              // 6
 		// size += DisSizes.UI16_SIZE;	// Radio ID          // 2
 
 		// size += encodingScheme.getByteLength();           // 2
-		// size += TdlType.getByteLength();                  // 1
+		// size += TdlType.getByteLength();                  // 2
 		// size += DisSizes.UI32_SIZE;		// Sample Rate   // 4
 		// size += DisSizes.UI16_SIZE;		// Data Length   // 2
 		// size += DisSizes.UI16_SIZE;		// Samples       // 2


### PR DESCRIPTION
- Previously the fixed length portion of the Signal PDU was incorrectly being reported as 19 bytes, which was off by one from the actual value of 20 bytes. The difference was that the calculation was incorrectly treating the TDL Type field as an 8-bit value instead of a 16-bit value that the spec prescribes.
- Updated `SignalPdu` so that the fixed portion of the length in `getContentLength()` is 20 bytes.