### PR TITLE
Multicast TTL now set correctly when creating sockets through Network Utils

### DIFF
--- a/codebase/build.properties
+++ b/codebase/build.properties
@@ -22,7 +22,7 @@
 #################################################################################
 build.longname = Open LVC Disco
 build.shortname = disco
-build.version = 1.1.0
+build.version = 1.1.1
 build.number = 1
 
 #################################

--- a/codebase/src/java/disco/org/openlvc/disco/utils/NetworkUtils.java
+++ b/codebase/src/java/disco/org/openlvc/disco/utils/NetworkUtils.java
@@ -26,6 +26,7 @@ import java.net.InetSocketAddress;
 import java.net.InterfaceAddress;
 import java.net.MulticastSocket;
 import java.net.NetworkInterface;
+import java.net.SocketAddress;
 import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -214,18 +215,20 @@ public class NetworkUtils
 			//                           and our address check against the send socket address will
 			//                           differ (valid address != 0.0.0.0 so it thinks they're from
 			//                           different PCs
-			DatagramSocket sendSocket = new DatagramSocket( 0, getFirstIPv4Address(nic) ); // ephemeral
+			SocketAddress sendAddr = new InetSocketAddress( getFirstIPv4Address(nic), 0 ); // ephemeral
+			MulticastSocket sendSocket = new MulticastSocket( sendAddr ); 
 			if( options != null )
 			{
 				sendSocket.setSendBufferSize( options.getSendBufferSize() );
 				sendSocket.setTrafficClass( options.getTrafficClass() );
+				sendSocket.setTimeToLive( options.timeToLive );
 			}
 			
 			// Create the receiver socket
 			MulticastSocket recvSocket = new MulticastSocket( port );
 			if( options != null )
 			{
-				recvSocket.setTimeToLive( options.timeToLive );
+				
 				//recvSocket.setLoopbackMode( true ); LEAVE LOCAL LOOPBACK ALONE.
 				recvSocket.setReceiveBufferSize( options.getRecvBufferSize() );
 			}


### PR DESCRIPTION
- Previously `NetworkUtils.createMulticastPair()` was incorrectly setting the multicast ttl value on the receive socket, rather than the send socket.
- Fixed this so that the value is now set on the send socket.
- Note: I've had to make the sender socket a `MulticastSocket` so that I could get access to the `setTtl()` method. I'm 99% it should be ok, as we're still constructing the socket with the same info (iface to bind to and ephemeral port), however you can never be too sure with multicast :p. Will keep an eye on performance over the coming weeks
- Also bumped the version up by 0.0.1 so that tracking the change is easier.