### PR TITLE
Fixes datalength field in EmitterBeam Record

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/pdu/emissions/EmitterBeam.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/emissions/EmitterBeam.java
@@ -20,8 +20,10 @@ package org.openlvc.disco.pdu.emissions;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 import org.openlvc.disco.pdu.DisInputStream;
 import org.openlvc.disco.pdu.DisOutputStream;
@@ -89,7 +91,41 @@ public class EmitterBeam implements IPduComponent, Cloneable
 	//----------------------------------------------------------
 	//                    INSTANCE METHODS
 	//----------------------------------------------------------
-
+	@Override
+	public boolean equals( Object other )
+	{
+		if( other == null )
+			return false;
+		
+		if( !(other instanceof EmitterBeam) )
+			return false;
+		
+		EmitterBeam otherBeam = (EmitterBeam)other;
+		return this.beamNumber == otherBeam.beamNumber &&
+		       this.parameterIndex == otherBeam.parameterIndex &&
+		       Objects.equals( this.parameterData, otherBeam.parameterData ) &&
+		       Objects.equals( this.beamData, otherBeam.beamData ) &&
+		       this.beamFunction == otherBeam.beamFunction &&
+		       this.highDensityTrackJam == otherBeam.highDensityTrackJam &&
+		       this.beamStatus == otherBeam.beamStatus &&
+		       Objects.equals( this.jammingTechnique, otherBeam.jammingTechnique ) &&
+		       Objects.equals( this.targets, otherBeam.targets );
+	}
+	
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash( this.beamNumber, 
+		                     this.parameterIndex,
+		                     this.parameterData,
+		                     this.beamData,
+		                     this.beamFunction,
+		                     this.highDensityTrackJam,
+		                     this.beamStatus,
+		                     this.jammingTechnique,
+		                     this.targets );
+	}
+	
 	@Override
 	public String toString()
 	{
@@ -97,14 +133,57 @@ public class EmitterBeam implements IPduComponent, Cloneable
 		if( highDensityTrackJam == HighDensityTrackJam.Selected )
 			targetString = "<High Density>";
 		
+		String parentString = "null";
+		if( parentSystem != null && parentSystem.getEmittingEntity() != null )
+			parentString = parentSystem.getEmittingEntity().toString();
+			
+		
 		//return "[1-23-45:0] (On) <Function> <Technique> <Targets>";
 		return String.format( "[%s:%d] (%3s) Function=%s, %s, Targets=%s",
-		                      parentSystem.getEmittingEntity(),
+		                      parentString,
 		                      beamNumber,
 		                      beamStatus.name(),
 		                      beamFunction.name(),
 		                      jammingTechnique.toString(),
 		                      targetString );
+	}
+	
+	/**
+	 * Creates a deep clone of this EmitterBeam
+	 * <p/>
+	 * Note: The off-spec parent system field that holds the upstream Emitter System that this
+	 * beam is a part of will not be deep cloned, but will instead refer to the original system. 
+	 */
+	@Override
+	public EmitterBeam clone()
+	{
+		return this.clone( this.parentSystem );
+	}
+	
+	/**
+	 * Creates a deep clone of this EmitterBeam
+	 * <p/>
+	 * The upstream parentSystem reference will be set to that provided.
+	 * <p/> 
+	 * This method is intended for chain cloning as part of {@link EmitterSystem#clone()} where a 
+	 * clone of the parent system has been created upstream.
+	 */
+	public EmitterBeam clone( EmitterSystem parentSystem )
+	{
+		EmitterBeam cloned = new EmitterBeam();
+		cloned.beamNumber = this.beamNumber;
+		cloned.parameterIndex = this.parameterIndex;
+		cloned.parameterData = this.parameterData.clone();
+		cloned.beamData = this.beamData.clone();
+		cloned.beamFunction = this.beamFunction;
+		cloned.highDensityTrackJam = this.highDensityTrackJam;
+		cloned.beamStatus = this.beamStatus;
+		cloned.jammingTechnique = this.jammingTechnique.clone();
+		this.targets.forEach( (key,value) -> cloned.targets.put(key, value.clone()) );
+		
+		cloned.parentSystem = parentSystem;
+		
+		return cloned;
 	}
 	
 	////////////////////////////////////////////////////////////////////////////////////////////
@@ -128,23 +207,17 @@ public class EmitterBeam implements IPduComponent, Cloneable
 		this.targets.clear();
 		for( int i = 0; i < numberOfTargets; i++ )
 		{
-			TrackJamData record = new TrackJamData();
-			record.from( dis );
-			targets.put( record.getTarget(), record );
+			TrackJamData targetRecord = new TrackJamData();
+			targetRecord.from( dis );
+			targets.put( targetRecord.getTarget(), targetRecord );
 		}
     }
 
 	@Override
     public void to( DisOutputStream dos ) throws IOException
     {
-		// ref DIS-7 spec section 7.6.2 paragraph f.5.i
-		// if length exceeds 255 this value is not used and should be set to 0
-		
-		int beamLength = getByteLength() / 4;  // Count in 32-bit words
-		if( beamLength > 255 )
-			beamLength = 0;
-
-		dos.writeUI8( (short)getByteLength() );
+		short dataLength = getDataLength();
+		dos.writeUI8( dataLength );
 		dos.writeUI8( beamNumber );
 		dos.writeUI16( parameterIndex );
 		parameterData.to( dos );
@@ -189,6 +262,31 @@ public class EmitterBeam implements IPduComponent, Cloneable
 	////////////////////////////////////////////////////////////////////////////////////////////
 	/// Helper Methods   ///////////////////////////////////////////////////////////////////////
 	////////////////////////////////////////////////////////////////////////////////////////////
+	/**
+	 * Returns the length of this structure in 32-bit words.
+	 * <p/>
+	 * If the 32-bit word length exceeds 255, then 0 is returned instead.
+	 * <p/>
+	 * This value is what is written to the data length field in the PDU. See DIS specification 
+	 * s7.6.2.
+	 * <p/>
+	 * For the length in bytes, please see {@link #getByteLength()}
+	 * 
+	 * @return the length of this structure in 32-bit words. If this figure would be greater than 
+	 *         255, then zero is returned
+	 */
+	public short getDataLength()
+	{
+		// ref DIS-7 spec section 7.6.2 paragraph f.5.i
+		// if length exceeds 255 this value is not used and should be set to 0
+		int byteLength = this.getByteLength();
+		int dataLength = byteLength / 4;
+		if( dataLength > 255 )
+			dataLength = 0;
+		
+		return (short)dataLength;
+	}
+	
 	public boolean isTargeting( EntityId id )
 	{
 		return targets.containsKey(id);
@@ -304,20 +402,21 @@ public class EmitterBeam implements IPduComponent, Cloneable
 		return targets.size();
 	}
 	
-	public Collection<TrackJamData> getTargets()
+	public Set<TrackJamData> getTargets()
 	{
-		return targets.values();
+		return new HashSet<>( targets.values() );
 	}
 
-	public void setTargets( List<TrackJamData> records )
+	public void setTargets( Collection<? extends TrackJamData> targetRecords )
 	{
 		this.targets.clear();
-		records.forEach( record -> this.targets.put(record.getTarget(),record) );
+		targetRecords.forEach( targetRecord -> this.targets.put(targetRecord.getTarget(),
+		                                                        targetRecord) );
 	}
 
-	public void addTarget( TrackJamData record )
+	public void addTarget( TrackJamData targetRecord )
 	{
-		this.targets.put( record.getTarget(), record );
+		this.targets.put( targetRecord.getTarget(), targetRecord );
 	}
 
 	/**
@@ -328,12 +427,12 @@ public class EmitterBeam implements IPduComponent, Cloneable
 	 */
 	public void addTarget( EntityId id )
 	{
-		TrackJamData record = new TrackJamData(id);
-		record.setBeamNumber( beamNumber );
+		TrackJamData targetRecord = new TrackJamData(id);
+		targetRecord.setBeamNumber( beamNumber );
 		if( parentSystem != null )
-			record.setEmitterNumber( parentSystem.getEmitterNumber() );
+			targetRecord.setEmitterNumber( parentSystem.getEmitterNumber() );
 		
-		targets.put( id, record );
+		targets.put( id, targetRecord );
 	}
 	
 	public void removeTarget( TrackJamData record )

--- a/codebase/src/java/disco/org/openlvc/disco/pdu/emissions/EmitterSystem.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/emissions/EmitterSystem.java
@@ -20,7 +20,9 @@ package org.openlvc.disco.pdu.emissions;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -73,7 +75,29 @@ public class EmitterSystem implements IPduComponent, Cloneable
 	//----------------------------------------------------------
 	//                    INSTANCE METHODS
 	//----------------------------------------------------------
-
+	@Override
+	public boolean equals( Object other )
+	{
+		if( other == null )
+			return false;
+		
+		if( !(other instanceof EmitterSystem) )
+			return false;
+		
+		EmitterSystem otherSystem = (EmitterSystem)other;
+		return Objects.equals( this.systemType, otherSystem.systemType ) &&
+		       Objects.equals( this.location, otherSystem.location ) &&
+		       Objects.equals( this.beams, otherSystem.beams );
+	}
+	
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash( this.systemType, 
+		                     this.location,
+		                     this.beams );
+	}
+	
 	@Override
 	public String toString()
 	{
@@ -107,12 +131,8 @@ public class EmitterSystem implements IPduComponent, Cloneable
 	{
 		// ref DIS-7 spec section 7.6.2 paragraph f.1
 		// if length exceeds 255 this value is not used and should be set to 0
-		short length = (short)(getByteLength() / 4);  // 32-bit words
-		if( length > 255 )
-		{
-			length = 0;
-		}
-		dos.writeUI8( length );
+		short dataLength = getDataLength();
+		dos.writeUI8( dataLength );
 		dos.writeUI8( (short)beams.size() );
 		dos.writePadding16();
 		systemType.to( dos );
@@ -161,6 +181,31 @@ public class EmitterSystem implements IPduComponent, Cloneable
 		                     .collect( Collectors.toSet() );
 	}
 
+	/**
+	 * Returns the length of this structure in 32-bit words.
+	 * <p/>
+	 * If the 32-bit word length exceeds 255, then 0 is returned instead.
+	 * <p/>
+	 * This value is what is written to the data length field in the PDU. See DIS specification 
+	 * s7.6.2.
+	 * <p/>
+	 * For the length in bytes, please see {@link #getByteLength()}
+	 * 
+	 * @return the length of this structure in 32-bit words. If this figure would be greater than 
+	 *         255, then zero is returned
+	 */
+	public short getDataLength()
+	{
+		// ref DIS-7 spec section 7.6.2 paragraph f.5.i
+		// if length exceeds 255 this value is not used and should be set to 0
+		int byteLength = this.getByteLength();
+		int dataLength = byteLength / 4;
+		if( dataLength > 255 )
+			dataLength = 0;
+		
+		return (short)dataLength;
+	}
+	
 	////////////////////////////////////////////////////////////////////////////////////////////
 	/// Accessor and Mutator Methods   /////////////////////////////////////////////////////////
 	////////////////////////////////////////////////////////////////////////////////////////////
@@ -191,7 +236,7 @@ public class EmitterSystem implements IPduComponent, Cloneable
 	
 	public Collection<EmitterBeam> getBeams()
 	{
-		return beams.values();
+		return new HashSet<>( beams.values() );
 	}
 
 	/**

--- a/codebase/src/java/disco/org/openlvc/disco/pdu/record/BeamData.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/record/BeamData.java
@@ -18,6 +18,7 @@
 package org.openlvc.disco.pdu.record;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.openlvc.disco.pdu.DisInputStream;
 import org.openlvc.disco.pdu.DisOutputStream;
@@ -69,7 +70,6 @@ public class BeamData implements IPduComponent, Cloneable
 	//----------------------------------------------------------
 	//                    INSTANCE METHODS
 	//----------------------------------------------------------
-
 	@Override
 	public boolean equals( Object object )
 	{
@@ -90,6 +90,16 @@ public class BeamData implements IPduComponent, Cloneable
 		}
 
 		return false;
+	}
+	
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash( this.azimuthCenter, 
+		                     this.azimuthSweep,
+		                     this.elevationCenter,
+		                     this.elevationSweep,
+		                     this.sweepSync );
 	}
 	
 	@Override

--- a/codebase/src/java/disco/org/openlvc/disco/pdu/record/EmitterSystemType.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/record/EmitterSystemType.java
@@ -18,6 +18,7 @@
 package org.openlvc.disco.pdu.record;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.openlvc.disco.pdu.DisInputStream;
 import org.openlvc.disco.pdu.DisOutputStream;
@@ -67,7 +68,6 @@ public class EmitterSystemType implements IPduComponent, Cloneable
 	//----------------------------------------------------------
 	//                    INSTANCE METHODS
 	//----------------------------------------------------------
-
 	@Override
 	public boolean equals( Object object )
 	{
@@ -86,6 +86,12 @@ public class EmitterSystemType implements IPduComponent, Cloneable
 		}
 
 		return false;
+	}
+	
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash( this.name, this.function, this.number );
 	}
 	
 	@Override

--- a/codebase/src/java/disco/org/openlvc/disco/pdu/record/FundamentalParameterData.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/record/FundamentalParameterData.java
@@ -18,6 +18,7 @@
 package org.openlvc.disco.pdu.record;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.openlvc.disco.pdu.DisInputStream;
 import org.openlvc.disco.pdu.DisOutputStream;
@@ -69,7 +70,6 @@ public class FundamentalParameterData implements IPduComponent, Cloneable
 	//----------------------------------------------------------
 	//                    INSTANCE METHODS
 	//----------------------------------------------------------
-
 	@Override
 	public boolean equals( Object object )
 	{
@@ -90,6 +90,16 @@ public class FundamentalParameterData implements IPduComponent, Cloneable
 		}
 
 		return false;
+	}
+	
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash( this.frequency, 
+		                     this.frequencyRange,
+		                     this.radiatedPower,
+		                     this.pulseRepetitionFrequency,
+		                     this.pulseWidth );
 	}
 	
 	@Override

--- a/codebase/src/java/disco/org/openlvc/disco/pdu/record/JammingTechnique.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/record/JammingTechnique.java
@@ -18,6 +18,7 @@
 package org.openlvc.disco.pdu.record;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.openlvc.disco.pdu.DisInputStream;
 import org.openlvc.disco.pdu.DisOutputStream;
@@ -63,7 +64,6 @@ public class JammingTechnique implements IPduComponent, Cloneable
 	//----------------------------------------------------------
 	//                    INSTANCE METHODS
 	//----------------------------------------------------------
-
 	@Override
 	public boolean equals( Object object )
 	{
@@ -83,6 +83,15 @@ public class JammingTechnique implements IPduComponent, Cloneable
 		}
 
 		return false;
+	}
+	
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash( this.kind, 
+		                     this.category,
+		                     this.subcategory,
+		                     this.specific );
 	}
 	
 	@Override

--- a/codebase/src/java/disco/org/openlvc/disco/pdu/record/TrackJamData.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/record/TrackJamData.java
@@ -18,6 +18,7 @@
 package org.openlvc.disco.pdu.record;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.openlvc.disco.pdu.DisInputStream;
 import org.openlvc.disco.pdu.DisOutputStream;
@@ -80,6 +81,14 @@ public class TrackJamData implements IPduComponent, Cloneable
 		}
 
 		return false;
+	}
+	
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash( this.target, 
+		                     this.emitterNumber,
+		                     this.beamNumber );
 	}
 	
 	@Override

--- a/codebase/src/java/disco/org/openlvc/disco/pdu/record/VectorRecord.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/record/VectorRecord.java
@@ -18,6 +18,7 @@
 package org.openlvc.disco.pdu.record;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import org.openlvc.disco.pdu.DisInputStream;
 import org.openlvc.disco.pdu.DisOutputStream;
@@ -80,6 +81,14 @@ public class VectorRecord implements IPduComponent, Cloneable
 		return false;
 	}
 
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash( this.firstComponent, 
+		                     this.secondComponent, 
+		                     this.thirdComponent );
+	}
+	
 	@Override
 	public VectorRecord clone()
 	{

--- a/codebase/src/java/test/org/openlvc/disco/pdu/EmitterBeamRecordTest.java
+++ b/codebase/src/java/test/org/openlvc/disco/pdu/EmitterBeamRecordTest.java
@@ -1,0 +1,234 @@
+/*
+ *   Copyright 2015 Open LVC Project.
+ *
+ *   This file is part of Open LVC Disco.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.openlvc.disco.pdu;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.openlvc.disco.AbstractTest;
+import org.openlvc.disco.pdu.emissions.EmitterBeam;
+import org.openlvc.disco.pdu.field.BeamFunction;
+import org.openlvc.disco.pdu.field.HighDensityTrackJam;
+import org.openlvc.disco.pdu.record.BeamData;
+import org.openlvc.disco.pdu.record.EntityId;
+import org.openlvc.disco.pdu.record.FundamentalParameterData;
+import org.openlvc.disco.pdu.record.JammingTechnique;
+import org.openlvc.disco.pdu.record.TrackJamData;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(groups={"record","EmitterBeam"})
+public class EmitterBeamRecordTest extends AbstractTest
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	///////////////////////////////////////////////////////////////////////////////////
+	/// Test Class Setup/Tear Down   //////////////////////////////////////////////////
+	///////////////////////////////////////////////////////////////////////////////////
+	@BeforeClass(alwaysRun=true)
+	public void beforeClass()
+	{
+		// no-op
+	}
+	
+	@BeforeMethod(alwaysRun=true)
+	public void beforeMethod()
+	{
+		// no-op
+	}
+
+	@AfterMethod(alwaysRun=true)
+	public void afterMethod()
+	{
+		// no-op
+	}
+	
+	@AfterClass(alwaysRun=true)
+	public void afterClass()
+	{
+		// no-op
+	}
+
+	///////////////////////////////////////////////////////////////////////////////////
+	/// PDU Testing Methods   /////////////////////////////////////////////////////////
+	///////////////////////////////////////////////////////////////////////////////////
+	@Test
+	public void testEmitterBeamSerialize() throws IOException
+	{
+		BeamData beamData = new BeamData(0.1f, 0.2f, 0.3f, 0.4f, 0.5f );
+		JammingTechnique jammingTechnique = new JammingTechnique( 1, 2, 3, 4 );
+		FundamentalParameterData fundamentalData = new FundamentalParameterData( 30000000f, 
+		                                                                         5000000f, 
+		                                                                         30f, 
+		                                                                         2000000f, 
+		                                                                         44000f ); 
+		EntityId targetId = new EntityId( 5, 6, 7 );
+		TrackJamData target = new TrackJamData( targetId, (short)8, (short)9 );
+		List<TrackJamData> targets = List.of( target );
+		
+		EmitterBeam beamRecord = new EmitterBeam();
+		beamRecord.setBeamActive( true );
+		beamRecord.setBeamData( beamData );
+		beamRecord.setBeamFunction( BeamFunction.Jamming );
+		beamRecord.setBeamNumber( (short)10 );
+		beamRecord.setHighDensity( HighDensityTrackJam.Selected );
+		beamRecord.setJammingTechnique( jammingTechnique );
+		beamRecord.setParameterData( fundamentalData );
+		beamRecord.setParameterIndex( 5 );
+		beamRecord.setTargets( targets );
+		
+		// Test byte length 
+		int expectedByteLength = 60; // 52 fixed + 8 for one target
+		int actualByteLength = beamRecord.getByteLength();
+		Assert.assertEquals( actualByteLength, expectedByteLength );
+		
+		// And also test data length (length in 32-bit words)
+		int expectedDataLength = 15; // byte length / 4
+		int actualDataLength = beamRecord.getDataLength();
+		Assert.assertEquals( actualDataLength, expectedDataLength );
+		
+		ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+		DisOutputStream dos = new DisOutputStream( bytesOut );
+		beamRecord.to( dos );
+		
+		byte[] dataRaw = bytesOut.toByteArray();
+		try( DisInputStream dis = new DisInputStream(dataRaw) )
+		{
+			// We want to ensure that the data length is written out correctly
+			int deserializedDataLength = dis.readUI8();
+			Assert.assertEquals( deserializedDataLength, expectedDataLength );
+
+			// And ensure that reading the whole structure back in produces the same result
+			dis.reset();
+			EmitterBeam deserialized = new EmitterBeam();
+			deserialized.from( dis );
+
+			// Ensure result is equal at the field level
+			Assert.assertEquals( deserialized.isBeamActive(), true );
+			Assert.assertEquals( deserialized.getBeamData(), beamData );
+			Assert.assertEquals( deserialized.getBeamFunction(), BeamFunction.Jamming );
+			Assert.assertEquals( deserialized.getBeamNumber(), (short)10 );
+			Assert.assertEquals( deserialized.getHighDensity(), HighDensityTrackJam.Selected );
+			Assert.assertEquals( deserialized.getJammingTechnique(), jammingTechnique );
+			Assert.assertEquals( deserialized.getParameterData(), fundamentalData );
+			Assert.assertEquals( deserialized.getParameterIndex(), 5 );
+			Assert.assertEquals( deserialized.getTargets(), targets );
+
+			// Ensure result is equal via equals()
+			Assert.assertEquals( deserialized, beamRecord );
+		}
+	}
+	
+	@Test
+	public void testEmitterBeamSerializeOversize() throws IOException
+	{
+		BeamData beamData = new BeamData(0.1f, 0.2f, 0.3f, 0.4f, 0.5f );
+		JammingTechnique jammingTechnique = new JammingTechnique( 1, 2, 3, 4 );
+		FundamentalParameterData fundamentalData = new FundamentalParameterData( 30000000f, 
+		                                                                         5000000f, 
+		                                                                         30f, 
+		                                                                         2000000f, 
+		                                                                         44000f );
+		
+		// Pump this baby full of targets so that its data length exceeds 255 32-bit words
+		Set<TrackJamData> targets = new HashSet<>();
+		for( int i = 0 ; i < 128 ; ++i )
+		{
+			EntityId entity = new EntityId( 1, 1, i+1 );
+			TrackJamData jamData = new TrackJamData( entity );
+			targets.add( jamData );
+		}
+		
+		EmitterBeam beamRecord = new EmitterBeam();
+		beamRecord.setBeamActive( true );
+		beamRecord.setBeamData( beamData );
+		beamRecord.setBeamFunction( BeamFunction.Jamming );
+		beamRecord.setBeamNumber( (short)10 );
+		beamRecord.setHighDensity( HighDensityTrackJam.Selected );
+		beamRecord.setJammingTechnique( jammingTechnique );
+		beamRecord.setParameterData( fundamentalData );
+		beamRecord.setParameterIndex( 5 );
+		beamRecord.setTargets( targets );
+		
+		// Test byte length 
+		int expectedByteLength = 1076; // 52 fixed + 8*128 targets
+		int actualByteLength = beamRecord.getByteLength();
+		Assert.assertEquals( actualByteLength, expectedByteLength );
+		
+		// And also test data length (length in 32-bit words)
+		int expectedDataLength = 0; // Would be 269 which exceeds 255, so will be set to 0
+		int actualDataLength = beamRecord.getDataLength();
+		Assert.assertEquals( actualDataLength, expectedDataLength );
+		
+		ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+		DisOutputStream dos = new DisOutputStream( bytesOut );
+		beamRecord.to( dos );
+		
+		byte[] dataRaw = bytesOut.toByteArray();
+		try( DisInputStream dis = new DisInputStream(dataRaw) )
+		{
+			// We want to ensure that the data length is written out correctly
+			int deserializedDataLength = dis.readUI8();
+			Assert.assertEquals( deserializedDataLength, expectedDataLength );
+
+			// And ensure that reading the whole structure back in produces the same result
+			dis.reset();
+			EmitterBeam deserialized = new EmitterBeam();
+			deserialized.from( dis );
+
+			// Ensure result is equal at the field level
+			Assert.assertEquals( deserialized.isBeamActive(), true );
+			Assert.assertEquals( deserialized.getBeamData(), beamData );
+			Assert.assertEquals( deserialized.getBeamFunction(), BeamFunction.Jamming );
+			Assert.assertEquals( deserialized.getBeamNumber(), (short)10 );
+			Assert.assertEquals( deserialized.getHighDensity(), HighDensityTrackJam.Selected );
+			Assert.assertEquals( deserialized.getJammingTechnique(), jammingTechnique );
+			Assert.assertEquals( deserialized.getParameterData(), fundamentalData );
+			Assert.assertEquals( deserialized.getParameterIndex(), 5 );
+			Assert.assertEquals( deserialized.getTargets(), targets );
+
+			// Ensure result is equal via equals()
+			Assert.assertEquals( deserialized, beamRecord );
+		}
+	}
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/test/org/openlvc/disco/pdu/EmitterSystemRecordTest.java
+++ b/codebase/src/java/test/org/openlvc/disco/pdu/EmitterSystemRecordTest.java
@@ -1,0 +1,259 @@
+/*
+ *   Copyright 2015 Open LVC Project.
+ *
+ *   This file is part of Open LVC Disco.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.openlvc.disco.pdu;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.random.RandomGenerator;
+import java.util.random.RandomGeneratorFactory;
+
+import org.openlvc.disco.AbstractTest;
+import org.openlvc.disco.pdu.emissions.EmitterBeam;
+import org.openlvc.disco.pdu.emissions.EmitterSystem;
+import org.openlvc.disco.pdu.field.BeamFunction;
+import org.openlvc.disco.pdu.field.EmitterSystemFunction;
+import org.openlvc.disco.pdu.field.HighDensityTrackJam;
+import org.openlvc.disco.pdu.record.BeamData;
+import org.openlvc.disco.pdu.record.EmitterSystemType;
+import org.openlvc.disco.pdu.record.EntityId;
+import org.openlvc.disco.pdu.record.FundamentalParameterData;
+import org.openlvc.disco.pdu.record.JammingTechnique;
+import org.openlvc.disco.pdu.record.TrackJamData;
+import org.openlvc.disco.pdu.record.VectorRecord;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(groups={"record","EmitterSystem"})
+public class EmitterSystemRecordTest extends AbstractTest
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	private EmitterBeam quickCreateBeam( int emitterNumber, int beamNumber, int targetCount )
+	{
+		final float FORIGIN = 20000;
+		final float FBOOUND = 40000;
+		final int UBYTEORIGIN = 128;
+		final int UBYTEBOUND = 255;
+		RandomGenerator gen = RandomGeneratorFactory.getDefault().create();
+		
+		
+		BeamData beamData = new BeamData( gen.nextFloat(FORIGIN, FBOOUND), 
+		                                  gen.nextFloat(FORIGIN, FBOOUND), 
+		                                  gen.nextFloat(FORIGIN, FBOOUND), 
+		                                  gen.nextFloat(FORIGIN, FBOOUND), 
+		                                  gen.nextFloat(FORIGIN, FBOOUND) );
+		JammingTechnique jammingTechnique = new JammingTechnique( gen.nextInt(UBYTEORIGIN, UBYTEBOUND), 
+		                                                          gen.nextInt(UBYTEORIGIN, UBYTEBOUND), 
+		                                                          gen.nextInt(UBYTEORIGIN, UBYTEBOUND), 
+		                                                          gen.nextInt(UBYTEORIGIN, UBYTEBOUND) );
+		FundamentalParameterData fundamentalData = new FundamentalParameterData( gen.nextFloat(FORIGIN, FBOOUND), 
+		                                                                         gen.nextFloat(FORIGIN, FBOOUND), 
+		                                                                         gen.nextFloat(FORIGIN, FBOOUND), 
+		                                                                         gen.nextFloat(FORIGIN, FBOOUND), 
+		                                                                         gen.nextFloat(FORIGIN, FBOOUND) ); 
+		
+		Set<TrackJamData> targets = new HashSet<>(); 
+		for( int i = 0 ; i < targetCount ; ++i )
+		{
+			EntityId targetId = new EntityId( gen.nextInt(UBYTEORIGIN, UBYTEBOUND), 
+			                                  gen.nextInt(UBYTEORIGIN, UBYTEBOUND), 
+			                                  gen.nextInt(UBYTEORIGIN, UBYTEBOUND) );
+			
+			TrackJamData target = new TrackJamData( targetId, 
+			                                        (short)emitterNumber, 
+			                                        (short)beamNumber );
+			targets.add( target );
+		}
+		
+		EmitterBeam beamRecord = new EmitterBeam();
+		beamRecord.setBeamActive( true );
+		beamRecord.setBeamData( beamData );
+		beamRecord.setBeamFunction( BeamFunction.Jamming );
+		beamRecord.setBeamNumber( (short)beamNumber );
+		beamRecord.setHighDensity( HighDensityTrackJam.Selected );
+		beamRecord.setJammingTechnique( jammingTechnique );
+		beamRecord.setParameterData( fundamentalData );
+		beamRecord.setParameterIndex( 0 );
+		beamRecord.setTargets( targets );
+		
+		return beamRecord;
+	}
+
+	///////////////////////////////////////////////////////////////////////////////////
+	/// Test Class Setup/Tear Down   //////////////////////////////////////////////////
+	///////////////////////////////////////////////////////////////////////////////////
+	@BeforeClass(alwaysRun=true)
+	public void beforeClass()
+	{
+		// no-op
+	}
+	
+	@BeforeMethod(alwaysRun=true)
+	public void beforeMethod()
+	{
+		// no-op
+	}
+
+	@AfterMethod(alwaysRun=true)
+	public void afterMethod()
+	{
+		// no-op
+	}
+	
+	@AfterClass(alwaysRun=true)
+	public void afterClass()
+	{
+		// no-op
+	}
+
+	///////////////////////////////////////////////////////////////////////////////////
+	/// PDU Testing Methods   /////////////////////////////////////////////////////////
+	///////////////////////////////////////////////////////////////////////////////////
+	@Test
+	public void testEmitterSystemSerialize() throws IOException
+	{
+		short emitterNumber = 2;
+		EmitterSystemType systemType = new EmitterSystemType( 1, 
+		                                                      EmitterSystemFunction.Jammer, 
+		                                                      emitterNumber );
+		
+		VectorRecord location = new VectorRecord( 3f, 4f, 5f );
+		
+		EmitterSystem systemRecord = new EmitterSystem();
+		systemRecord.setSystemType( systemType );
+		systemRecord.setLocation( location );
+		
+		EmitterBeam beam = quickCreateBeam( emitterNumber, 1, 1 );
+		systemRecord.addBeam( beam );
+		
+		// Test byte and data lengths
+		int expectedByteLength = 20 + 60; // 20 fixed portion + 60 for beam with single target
+		int actualByteLength = systemRecord.getByteLength();
+		Assert.assertEquals( actualByteLength, expectedByteLength );
+		
+		int expectedDataLength = 20; // byteLength / 4 (no of 32-bit words)
+		int actualDataLength = systemRecord.getDataLength();
+		Assert.assertEquals( actualDataLength, expectedDataLength );
+		
+		// Serialize record
+		ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+		DisOutputStream dos = new DisOutputStream( bytesOut );
+		systemRecord.to( dos );
+		
+		byte[] dataRaw = bytesOut.toByteArray();
+		try( DisInputStream dis = new DisInputStream(dataRaw) )
+		{
+			// We want to ensure that the data length is written out correctly
+			int deserializedDataLength = dis.readUI8();
+			Assert.assertEquals( deserializedDataLength, expectedDataLength );
+			
+			// And ensure that reading the whole structure back in produces the same result
+			dis.reset();
+			EmitterSystem deserialized = new EmitterSystem();
+			deserialized.from( dis );
+			
+			// Ensure result is equal at the field level
+			Assert.assertEquals( deserialized.getSystemType(), systemRecord.getSystemType() );
+			Assert.assertEquals( deserialized.getLocation(), systemRecord.getLocation() );
+			Assert.assertEquals( deserialized.getBeams(), systemRecord.getBeams() );
+			
+			// Ensure result is equal by equals()
+			Assert.assertEquals( deserialized, systemRecord );
+		}
+	}
+	
+	@Test
+	public void testEmitterSystemSerializeOversize() throws IOException
+	{
+		short emitterNumber = 2;
+		EmitterSystemType systemType = new EmitterSystemType( 1, 
+		                                                      EmitterSystemFunction.Jammer, 
+		                                                      emitterNumber );
+		
+		VectorRecord location = new VectorRecord( 3f, 4f, 5f );
+		
+		EmitterSystem systemRecord = new EmitterSystem();
+		systemRecord.setSystemType( systemType );
+		systemRecord.setLocation( location );
+		
+		// Pump this baby full of beams so that its data length exceeds 255 32-bit words
+		for( int i = 0 ; i < 18 ; ++i )
+		{
+			EmitterBeam beam = quickCreateBeam( emitterNumber, i+1, 1 );
+			systemRecord.addBeam( beam );
+		}
+		
+		// Test byte and data lengths
+		int expectedByteLength = 1100; // 20 fixed portion + (18 * 60) for 18 beams with single target
+		int actualByteLength = systemRecord.getByteLength();
+		Assert.assertEquals( actualByteLength, expectedByteLength );
+		
+		int expectedDataLength = 0; // Would be 275, which is greater than 255, so set to 0
+		int actualDataLength = systemRecord.getDataLength();
+		Assert.assertEquals( actualDataLength, expectedDataLength );
+		
+		// Serialize record
+		ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
+		DisOutputStream dos = new DisOutputStream( bytesOut );
+		systemRecord.to( dos );
+		
+		byte[] dataRaw = bytesOut.toByteArray();
+		try( DisInputStream dis = new DisInputStream(dataRaw) )
+		{
+			// We want to ensure that the data length is written out correctly
+			int deserializedDataLength = dis.readUI8();
+			Assert.assertEquals( deserializedDataLength, expectedDataLength );
+			
+			// And ensure that reading the whole structure back in produces the same result
+			dis.reset();
+			EmitterSystem deserialized = new EmitterSystem();
+			deserialized.from( dis );
+			
+			// Ensure result is equal at the field level
+			Assert.assertEquals( deserialized.getSystemType(), systemRecord.getSystemType() );
+			Assert.assertEquals( deserialized.getLocation(), systemRecord.getLocation() );
+			Assert.assertEquals( deserialized.getBeams(), systemRecord.getBeams() );
+			
+			// Ensure result is equal by equals()
+			Assert.assertEquals( deserialized, systemRecord );
+		}
+	}
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}


### PR DESCRIPTION
- Was previously reporting size in 8-bit words instead of the 32-bit words that the spec dictates
- Have added unit tests to ensure both EmitterBeam and EmitterSystem data lengths are reported correctly
- Added hashCode() method to datatypes related to EmitterBeam and EmitterSystem that had equals() implemented. Keeps the linter happy
- Note: Will need to pull this up to master