### PR TITLE
Allow disrespector library users to provide their own logger

### DIFF
--- a/codebase/build.properties
+++ b/codebase/build.properties
@@ -23,7 +23,7 @@
 build.longname = Open LVC Disco
 build.shortname = disco
 build.version = 1.1.1
-build.number = 3
+build.number = 4
 
 #################################
 # Java Development Kit Settings #


### PR DESCRIPTION
- Previously disrespector created its own log files for both the hla and dis sides.
- This change allows library users of disrespector to specify their own logger to use via disrespector's configuration class.
- If a custom logger is provided, then it will be passed onto the dis/hla connections that disrespector manages on startup, rather than creating the normal log files
- Updates build.properties to 1.1.1.4