### PR TITLE
Custom PDUTypes are now registered in HLA config for disrespector

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disrespector/Configuration.java
+++ b/codebase/src/java/disco/org/openlvc/disrespector/Configuration.java
@@ -371,6 +371,10 @@ public class Configuration
 		hla.getLoggingConfiguration().setLevel( getHlaLogLevel() );
 		hla.getLoggingConfiguration().setFile( getHlaLogFile() );
 		
+		// 	We also have to tell the HLA side about our custom PDU types
+		for( Class<? extends PDU> customPduType : this.customPduTypes )
+			hla.getDisConfiguration().registerCustomPdu( customPduType );
+		
 		return hla;
 	}
 


### PR DESCRIPTION
- Initially didn't register the custom PDUTypes on the HLA side because I thought the mappers would just create them all directly rather than through the PduFactory
- Was getting unsupported pdu warnings in production, so it looks like they need to be registered