### PR TITLE
Removes registration of non-RPR standard RFModulationType alternatives

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/objects/RadioTransmitter.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/objects/RadioTransmitter.java
@@ -27,6 +27,7 @@ import org.openlvc.disco.connection.rpr.types.basic.StreamTag;
 import org.openlvc.disco.connection.rpr.types.enumerated.CryptographicModeEnum32;
 import org.openlvc.disco.connection.rpr.types.enumerated.CryptographicSystemTypeEnum16;
 import org.openlvc.disco.connection.rpr.types.enumerated.EnumHolder;
+import org.openlvc.disco.connection.rpr.types.enumerated.MajorRFModulationTypeEnum16;
 import org.openlvc.disco.connection.rpr.types.enumerated.RFmodulationSystemTypeEnum16;
 import org.openlvc.disco.connection.rpr.types.enumerated.RPRboolean;
 import org.openlvc.disco.connection.rpr.types.enumerated.RadioInputSourceEnum8;
@@ -43,6 +44,8 @@ import org.openlvc.disco.pdu.field.MajorModulationType;
 import org.openlvc.disco.pdu.field.ModulationSystem;
 import org.openlvc.disco.pdu.field.TransmitState;
 import org.openlvc.disco.pdu.radio.TransmitterPdu;
+
+import hla.rti1516e.encoding.DataElement;
 
 /**
  *  > HLAobjectRoot.EmbeddedSystem
@@ -249,8 +252,16 @@ public class RadioTransmitter extends EmbeddedSystem
 		pdu.getModulationType().setSystem( ModulationSystem.fromValue(rfModulationSystemType.getEnum().getValue()) );
 
 		// RFModulationType
-		pdu.getModulationType().setMajorModulationType( MajorModulationType.fromValue(rfModulationType.getDiscriminant().getValue()) );
-		pdu.getModulationType().setDetail( ((RPRunsignedInteger16BE)rfModulationType.getValue()).getValue() );
+		// Note: rfModulationType's value can be null here as the RPR FOM does not provide a
+		// full set of alternative variant types for every possible value of its discriminant 
+		// enum (MajorRFModulationTypeEnum16). E.g. MajorRFModulationTypeEnum16.Other is a valid 
+		// discriminant value, but has no alternative listed under RFmodulationTypeVariantStruct
+		MajorRFModulationTypeEnum16 hlaMajorModulationType = rfModulationType.getDiscriminant();
+		MajorModulationType disMajorModulationType = MajorModulationType.fromValue( hlaMajorModulationType.getValue() );
+		pdu.getModulationType().setMajorModulationType( disMajorModulationType );
+		DataElement value = rfModulationType.getValue();
+		int rawValue = value != null ? ((RPRunsignedInteger16BE)value).getValue() : 0;
+		pdu.getModulationType().setDetail( rawValue );
 
 		// SpreadSpectrum
 		// FIXME

--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/types/variant/RFmodulationTypeVariantStruct.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/types/variant/RFmodulationTypeVariantStruct.java
@@ -18,7 +18,13 @@
 package org.openlvc.disco.connection.rpr.types.variant;
 
 import org.openlvc.disco.connection.rpr.types.basic.RPRunsignedInteger16BE;
+import org.openlvc.disco.connection.rpr.types.enumerated.AmplitudeAngleModulationTypeEnum16;
+import org.openlvc.disco.connection.rpr.types.enumerated.AmplitudeModulationTypeEnum16;
+import org.openlvc.disco.connection.rpr.types.enumerated.AngleModulationTypeEnum16;
+import org.openlvc.disco.connection.rpr.types.enumerated.CombinationModulationTypeEnum16;
 import org.openlvc.disco.connection.rpr.types.enumerated.MajorRFModulationTypeEnum16;
+import org.openlvc.disco.connection.rpr.types.enumerated.PulseModulationTypeEnum16;
+import org.openlvc.disco.connection.rpr.types.enumerated.UnmodulatedTypeEnum16;
 import org.openlvc.disco.pdu.field.MajorModulationType;
 
 import hla.rti1516e.encoding.ByteWrapper;
@@ -39,18 +45,31 @@ public class RFmodulationTypeVariantStruct extends WrappedHlaVariantRecord<Major
 	//----------------------------------------------------------
 	public RFmodulationTypeVariantStruct()
 	{
-		super( MajorRFModulationTypeEnum16.Other );
-		
-		super.setVariant( MajorRFModulationTypeEnum16.Other,             new RPRunsignedInteger16BE(0) );
-		super.setVariant( MajorRFModulationTypeEnum16.Amplitude,         new RPRunsignedInteger16BE(1) );
-		super.setVariant( MajorRFModulationTypeEnum16.AmplitudeAndAngle, new RPRunsignedInteger16BE(2) );
-		super.setVariant( MajorRFModulationTypeEnum16.Angle,             new RPRunsignedInteger16BE(3) );
-		super.setVariant( MajorRFModulationTypeEnum16.Combination,       new RPRunsignedInteger16BE(4) );
-		super.setVariant( MajorRFModulationTypeEnum16.Pulse,             new RPRunsignedInteger16BE(5) );
-		super.setVariant( MajorRFModulationTypeEnum16.Unmodulated,       new RPRunsignedInteger16BE(6) );
-		super.setVariant( MajorRFModulationTypeEnum16.CPSM,              new RPRunsignedInteger16BE(7) );
-		super.setVariant( MajorRFModulationTypeEnum16.SATCOM,            new RPRunsignedInteger16BE(8) );
+		super( MajorRFModulationTypeEnum16.Amplitude );
 
+		// These are technically enum types (see commented block below), but to handle them 
+		// generically in RadioTransmitter#toPdu() we just shortcut to the raw representation of
+		// RPRunsignedInteger16BE
+		super.setVariant( MajorRFModulationTypeEnum16.Amplitude,
+		                  new RPRunsignedInteger16BE(AmplitudeModulationTypeEnum16.Other.getValue()) );
+		super.setVariant( MajorRFModulationTypeEnum16.AmplitudeAndAngle, 
+		                  new RPRunsignedInteger16BE(AmplitudeAngleModulationTypeEnum16.Other.getValue()) );
+		super.setVariant( MajorRFModulationTypeEnum16.Angle,
+		                  new RPRunsignedInteger16BE(AngleModulationTypeEnum16.Other.getValue()) );
+		super.setVariant( MajorRFModulationTypeEnum16.Combination,
+		                  new RPRunsignedInteger16BE(CombinationModulationTypeEnum16.Other.getValue()) );
+		super.setVariant( MajorRFModulationTypeEnum16.Pulse,
+		                  new RPRunsignedInteger16BE(PulseModulationTypeEnum16.Other.getValue()) );
+		super.setVariant( MajorRFModulationTypeEnum16.Unmodulated,
+		                  new RPRunsignedInteger16BE(UnmodulatedTypeEnum16.Other.getValue()) );
+		
+		// Non-RPR standard values (they're in the DIS standard)
+		super.setVariant( MajorRFModulationTypeEnum16.CPSM,
+		                  new RPRunsignedInteger16BE(0) );
+		super.setVariant( MajorRFModulationTypeEnum16.SATCOM,
+		                  new RPRunsignedInteger16BE(0) );
+
+		// Historical
 //		super.setVariant( MajorRFModulationTypeEnum16.Other, EnumHolder.from(MajorRFModulationTypeEnum16.Other) );
 //		super.setVariant( MajorRFModulationTypeEnum16.Amplitude, EnumHolder.from(AmplitudeModulationTypeEnum16.Other) );
 //		super.setVariant( MajorRFModulationTypeEnum16.AmplitudeAndAngle, EnumHolder.from(AmplitudeAngleModulationTypeEnum16.Other) );


### PR DESCRIPTION
- Previously we were registering variant values for `Other`, `CPSM` and `SATCOM` in our implementation of RFmodulationTypeVariantStruct. These values have no alternatives in the RPR FOM, so we can't guarantee that systems will send value payloads for them
- Have removed registration of the non-RPR standard types in the `RFmodulationTypeVariantStruct` constructor. Under tested RTI encoding libraries (Pitch, Portico) this will decode just the discriminant, and leave the value as null
- Have added null check in `RadioTransmitter#toPdu()` when we try and interpret the `RFmodulationTypeVariantStruct`'s value. If its null, we just set the DIS equivalent to 0