### PR TITLE
Updates UdpConfiguration to allow setting max datagram size

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/configuration/UdpConfiguration.java
+++ b/codebase/src/java/disco/org/openlvc/disco/configuration/UdpConfiguration.java
@@ -17,6 +17,7 @@
  */
 package org.openlvc.disco.configuration;
 
+import java.io.EOFException;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InterfaceAddress;
@@ -24,6 +25,7 @@ import java.net.NetworkInterface;
 import java.net.UnknownHostException;
 
 import org.openlvc.disco.DiscoException;
+import org.openlvc.disco.pdu.DisSizes;
 import org.openlvc.disco.utils.NetworkUtils;
 import org.openlvc.disco.utils.StringUtils;
 
@@ -39,7 +41,8 @@ public class UdpConfiguration
 	private static final String PROP_SEND_BUFFER  = "disco.udp.sendBuffer";
 	private static final String PROP_RECV_BUFFER  = "disco.udp.recvBuffer";
 	private static final String PROP_TTL          = "disco.udp.ttl";
-	private static final String PROP_TRAFFIC_CLASS= "disco.udp.trafficClass"; 
+	private static final String PROP_TRAFFIC_CLASS= "disco.udp.trafficClass";
+	private static final String PROP_MAX_PDU_SIZE = "disco.udp.maxPduSize";
 
 	//----------------------------------------------------------
 	//                   INSTANCE VARIABLES
@@ -257,7 +260,7 @@ public class UdpConfiguration
 	
 	public void setSendBufferSize( int bytes )
 	{
-		parent.setProperty(PROP_SEND_BUFFER,""+bytes );
+		parent.setProperty(PROP_SEND_BUFFER,bytes+"B" );
 	}
 
 	public int getRecvBufferSize()
@@ -267,7 +270,7 @@ public class UdpConfiguration
 
 	public void setRecvBufferSize( int bytes )
 	{
-		parent.setProperty(PROP_RECV_BUFFER,""+bytes );
+		parent.setProperty(PROP_RECV_BUFFER,bytes+"B" );
 	}
 	
 	public int getTimeToLive()
@@ -290,6 +293,33 @@ public class UdpConfiguration
 		parent.setProperty( PROP_TRAFFIC_CLASS, String.valueOf(clasz) );
 	}
 
+	/**
+	 * Returns the buffer size that will be allocated for reading a PDU from a UDP Datagram
+	 * <p/>
+	 * Some systems may take advantage of IP4 Fragmentation and send Datagrams that are beyond the 
+	 * size of the UDP Maximum Transmission Unit (1500 bytes). In this case the IP layer will 
+	 * fragment the Datagram over several UDP packets and reassemble the Datagram on the other side 
+	 * before handing it to the application layer.
+	 * <p/>
+	 * This value represents the size of the buffer that DISCO will use when reading the complete
+	 * Datagram from the application layer. 
+	 * <p/>
+	 * If you are constantly receiving {@link EOFException}s when receiving PDUs then consider
+	 * increasing the size of the buffer by calling {@link #setMaxPduSize(int)}
+	 * 
+	 * @return the buffer size that will be allocated for reading a PDU from a UDP Datagram, 
+	 *         specified in bytes
+	 */
+	public int getMaxPduSize()
+	{
+		return Integer.parseInt( parent.getProperty(PROP_MAX_PDU_SIZE, Integer.toString(DisSizes.PDU_MAX_SIZE)) );
+	}
+	
+	public void setMaxPduSize( int bytes )
+	{
+		parent.setProperty( PROP_MAX_PDU_SIZE, Integer.toString(bytes) );
+	}
+	
 	//----------------------------------------------------------
 	//                     STATIC METHODS
 	//----------------------------------------------------------

--- a/codebase/src/java/disco/org/openlvc/disco/connection/UdpConnection.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/UdpConnection.java
@@ -33,7 +33,6 @@ import org.openlvc.disco.DiscoException;
 import org.openlvc.disco.OpsCenter;
 import org.openlvc.disco.configuration.UdpConfiguration;
 import org.openlvc.disco.pdu.DisOutputStream;
-import org.openlvc.disco.pdu.DisSizes;
 import org.openlvc.disco.pdu.PDU;
 import org.openlvc.disco.pdu.field.PduType;
 import org.openlvc.disco.utils.NetworkUtils;
@@ -278,7 +277,7 @@ public class UdpConnection implements IConnection
 				try
 				{
 					// 1. Receive the packet
-					byte[] buffer = new byte[DisSizes.PDU_MAX_SIZE];
+					byte[] buffer = new byte[configuration.getMaxPduSize()];
 					DatagramPacket packet = new DatagramPacket( buffer, buffer.length );
 					recvSocket.receive( packet );
 				


### PR DESCRIPTION
The current `UdpConnection` code caps the maximum size a UDP received PDU can be to the MTU limit of 1500 bytes. 

However, the MTU is only imposed at the UDP layer. If a datagram goes beyond this size then the IP layer will fragment it over multiple UDP frames (of MTU size) and reassemble it on the other side before passing it to the Application layer.

This means that it is possible for a `DatagramSocket` (like the one used in Disco's `UdpConnection`) to receive a `Datagram` that is beyond the 1500 byte limit.

Have added an option in `UdpConfiguration` so that the library user can specify the size of the Datagram buffer that will be read into. This is initially just set to the MTU limit, but can be adjusted to taste.