### PR TITLE
Add support for a FOM module override directory to RPR connection

### DIFF
--- a/codebase/resources/testdata/hla/fomOverride/HLAstandardMIM.xml
+++ b/codebase/resources/testdata/hla/fomOverride/HLAstandardMIM.xml
@@ -1,0 +1,2939 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- The IEEE hereby grants a general, royalty-free license to copy, distribute, -->
+<!-- display and make derivative works from this material, for all purposes,     -->
+<!-- provided that any use of the material contains the following                -->
+<!-- attribution: "Reprinted with permission from IEEE 1516.1(TM)-2010".         -->
+<!-- Should you require additional information, contact the Manager, Standards   -->
+<!-- Intellectual Property, IEEE Standards Association (stds-ipr@ieee.org).      -->
+<objectModel xmlns="http://standards.ieee.org/IEEE1516-2010" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://standards.ieee.org/IEEE1516-2010 http://standards.ieee.org/downloads/1516/1516.2-2010/IEEE1516-DIF-2010.xsd">
+   <modelIdentification>
+      <name>Standard MOM and Initialization Module (MIM) for HLA IEEE 1516-2010</name>
+      <type>FOM</type>
+      <version>1.0</version>
+      <modificationDate>2010-08-16</modificationDate>
+      <securityClassification>Unclassified</securityClassification>
+      <purpose>Standard MOM and Initialization Module for HLA IEEE 1516-2010</purpose>
+      <applicationDomain>HLA General</applicationDomain>
+      <description>The MOM Object Classes and Interaction Classes of this object model may be extended.</description>
+      <poc>
+         <pocType>Standards Sponsor</pocType>
+         <pocName>Simulation Interoperability Standards Organization</pocName>
+         <pocOrg>SISO</pocOrg>
+         <pocTelephone>+1 (407) 882-1348</pocTelephone>
+         <pocEmail>info@sisostds.org</pocEmail>
+      </poc>
+      <glyph alt="MOM and Initialization Module" type="GIF">
+         R0lGODlhIAAgAMQAAPeUHYFNDwAAAP3ozYRPD61oFMp5GJNYEfmzX/zbs/vIi/ihOOWJG0InCLVtFfmpStSFJiEUBFIxCtaAGZRZETEeBhAKAsZ2F2M7DHNFDgAAAAAAAAAAAAAAAAAAAAAAACH5BAAAAAAALAAAAAAgACAAAAX/YCCOZGme5aCubOu+qgjP9ComeK7vfI+LiqBwSCwagyKEcslsOp9K0WJKrVqv2KnoAeh6v+CwGLIVm89fcoCLbofV3AmB4PBS5l0CJa/3OuYTAHAADgICDV6GAl2HjIZeDYZ1g4WPhIqMiACKdZuSgmWFFQIXAAQCo5mMowQAF6gCk6ECGQKtEhWRqpsNFRKmtLGga5cEEb8WGLq8mRgWABIRp7LEhQQYERMCFMuNvBQCExEY08Nc1uCnE92ah9qnd8KUttoREQDsqvbh5fOtFgJ+5WMmQcCzfrNu2cK3iBmzU78QVlt4qtTARq9aSWTjpqM5jx4HgXQjciQaNQxSL6pcybKly5QiDMicSbOmzZsyRRTYybOnz59Ad4o4QLSo0aNIkxJFwbSp06dQRYQAADs=
+      </glyph>
+   </modelIdentification>
+   <objects>
+      <objectClass>
+         <name>HLAobjectRoot</name>
+         <sharing>Neither</sharing>
+         <attribute>
+            <name>HLAprivilegeToDeleteObject</name>
+            <dataType>HLAtoken</dataType>
+            <updateType>Static</updateType>
+            <updateCondition>NA</updateCondition>
+            <ownership>DivestAcquire</ownership>
+            <sharing>PublishSubscribe</sharing>
+            <transportation>HLAreliable</transportation>
+            <order>TimeStamp</order>
+         </attribute>
+         <objectClass>
+            <name>HLAmanager</name>
+            <sharing>Neither</sharing>
+            <semantics>This object class is the root class of all MOM object classes</semantics>
+            <objectClass>
+               <name>HLAfederate</name>
+               <sharing>Publish</sharing>
+               <semantics>This object class shall contain RTI state variables relating to a joined federate. The RTI
+                  shall publish it and shall register one object instance for each joined federate in a federation.
+                  Dynamic attributes that shall be contained in an object instance shall be updated periodically, where
+                  the period should be determined by an interaction of the class
+                  HLAmanager.HLAfederate.HLAadjust.HLAsetTiming. If this value is never set or is set to zero, no
+                  periodic update shall be performed by the RTI.
+
+                  The RTI shall respond to the invocation, by any federate, of the Request Attribute Value Update
+                  service for this object class or for any instance attribute of an object instance of this class by
+                  supplying values via the normal instance attribute update mechanism, regardless of whether the
+                  attribute has a data type of static, periodic, or conditional. In addition to its responsibility to
+                  update attributes of object instances of this class when those updates are explicitly requested, the
+                  RTI shall automatically update instance attributes of object instances of this class according to the
+                  update policy of the attribute, which is determined by the update type of the class attribute in Table
+                  6. For those attributes that have an update type of Periodic, the update wall-clock time interval
+                  shall be determined by the HLAreportPeriod parameter in an interaction of classHLAmanager.HLAfederate.
+                  HLAadjust.HLAsetTiming. If this value is never set or is set to zero, no periodic updates shall be
+                  performed by the RTI. Those attributes that have an update type of Conditional shall have update
+                  conditions as defined in the Table 6.
+               </semantics>
+               <attribute>
+                  <name>HLAfederateHandle</name>
+                  <dataType>HLAhandle</dataType>
+                  <updateType>Static</updateType>
+                  <updateCondition>NA</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Handle of the joined federate returned by a Join Federation Execution service invocation
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAfederateName</name>
+                  <dataType>HLAunicodeString</dataType>
+                  <updateType>Static</updateType>
+                  <updateCondition>NA</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>
+                     Name of the joined federate supplied to a successful Join Federation Execution service invocation
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAfederateType</name>
+                  <dataType>HLAunicodeString</dataType>
+                  <updateType>Static</updateType>
+                  <updateCondition>NA</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Type of the joined federate specified by the joined federate when it joined the federation
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAfederateHost</name>
+                  <dataType>HLAunicodeString</dataType>
+                  <updateType>Static</updateType>
+                  <updateCondition>NA</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Host name of the computer on which the joined federate is executing</semantics>
+               </attribute>
+               <attribute>
+                  <name>HLARTIversion</name>
+                  <dataType>HLAunicodeString</dataType>
+                  <updateType>Static</updateType>
+                  <updateCondition>NA</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Version of the RTI software being used</semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAFOMmoduleDesignatorList</name>
+                  <dataType>HLAmoduleDesignatorList</dataType>
+                  <updateType>Static</updateType>
+                  <updateCondition>NA</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>FOM Module designators as specified by the federate when the Join Federation Execution
+                     service was invoked. If several identical FOM modules are provided only the designator of the first
+                     of these FOM modules shall be added to the list.
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAtimeConstrained</name>
+                  <dataType>HLAboolean</dataType>
+                  <updateType>Conditional</updateType>
+                  <updateCondition>
+                     Whenever services Time Constrained Enabled or Disable Time Constrained are successfully invoked
+                     (including via the HLAdisableTimeConstrained interaction).
+                  </updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Whether the time advancement of the joined federate is constrained by other joined federates
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAtimeRegulating</name>
+                  <dataType>HLAboolean</dataType>
+                  <updateType>Conditional</updateType>
+                  <updateCondition>
+                     Whenever services Time Regulation Enabled or Disable Time Regulation are successfully invoked
+                     (including via the HLAdisableTimeRegulation interaction).
+                  </updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Whether the joined federate influences the time advancement of other joined federates
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAasynchronousDelivery</name>
+                  <dataType>HLAboolean</dataType>
+                  <updateType>Conditional</updateType>
+                  <updateCondition>Whenever services Enable Asynchronous Delivery or Disable Asynchronous Delivery are
+                     successfully invoked (including via the HLAenableAsynchronousDelivery or
+                     HLAdisableAsynchronousDelivery interactions).
+                  </updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Whether the RTI shall deliver RO messages to the joined federate while the joined
+                     federate's time manager state is not "Time Advancing" (only matters if the joined federate is
+                     time-constrained).
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAfederateState</name>
+                  <dataType>HLAfederateState</dataType>
+                  <updateType>Conditional</updateType>
+                  <updateCondition>Whenever the services Initiate Federate Save, Federation Saved, Federation Restore
+                     Begun, Confirm Federation Restoration Request (success), or Join Federation Execution are
+                     successfully invoked. Also, after the Federation Restored service has been invoked at all federates
+                     in the federation execution. If a joined federate is in the Federate Save in Progress state, no
+                     corresponding reflects shall be invoked at that joined federate.
+                  </updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>State of the joined federate. The MOM may, but is not required to, update any
+                     HLAfederateState instance attribute values during the interval after the last federate in the
+                     federation execution invokes the Federate Restore Complete service but before the last Federation
+                     Restored † callback is invoked at some federate for a given federation restoration.
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAtimeManagerState</name>
+                  <dataType>HLAtimeState</dataType>
+                  <updateType>Conditional</updateType>
+                  <updateCondition>Whenever services Time Advance Request, Time Advance Request Available, Next Message
+                     Request, Next Message Request Available, Flush Queue Request, or Time Advance Grant are
+                     successfully invoked (including via the HLAtimeAdvanceRequest, HLAtimeAdvanceRequestAvailable,
+                     HLAnextMessageRequest, HLAnextMessageRequestAvailable, or HLAflushQueueRequest interactions).
+                  </updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>State of the joined federate's time manager</semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAlogicalTime</name>
+                  <dataType>HLAlogicalTime</dataType>
+                  <updateType>Periodic</updateType>
+                  <updateCondition>HLAsetTiming.HLAreportPeriod</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Joined federate's logical time. Initial value of this information is initial value of
+                     federation time of the Time Representation Abstract Data Type (TRADT).
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAlookahead</name>
+                  <dataType>HLAtimeInterval</dataType>
+                  <updateType>Periodic</updateType>
+                  <updateCondition>HLAsetTiming.HLAreportPeriod</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Minimum duration into the future that a TSO message will be scheduled. The value shall not
+                     be defined if the joined federate is not time-regulating)
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAGALT</name>
+                  <dataType>HLAlogicalTime</dataType>
+                  <updateType>Periodic</updateType>
+                  <updateCondition>HLAsetTiming.HLAreportPeriod</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Joined federate's Greatest Available Logical Time (GALT). The value shall not be defined if
+                     GALT is not defined for the joined federate.
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLALITS</name>
+                  <dataType>HLAlogicalTime</dataType>
+                  <updateType>Periodic</updateType>
+                  <updateCondition>HLAsetTiming.HLAreportPeriod</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Joined federate's Least Incoming Time Stamp (LITS). The value shall not be defined if LITS
+                     is not defined for the joined federate.
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAROlength</name>
+                  <dataType>HLAcount</dataType>
+                  <updateType>Periodic</updateType>
+                  <updateCondition>HLAsetTiming.HLAreportPeriod</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Number of RO messages queued for delivery to the joined federate.</semantics>
+               </attribute>
+               <attribute>
+                  <name>HLATSOlength</name>
+                  <dataType>HLAcount</dataType>
+                  <updateType>Periodic</updateType>
+                  <updateCondition>HLAsetTiming.HLAreportPeriod</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Number of TSO messages queued for delivery to the joined federate</semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAreflectionsReceived</name>
+                  <dataType>HLAcount</dataType>
+                  <updateType>Periodic</updateType>
+                  <updateCondition>HLAsetTiming.HLAreportPeriod</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Total number of times the Reflect Attribute Values † service has been invoked at the joined
+                     federate (as opposed to the number of instance attribute value reflections that have been received
+                     at the joined federate).
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAupdatesSent</name>
+                  <dataType>HLAcount</dataType>
+                  <updateType>Periodic</updateType>
+                  <updateCondition>HLAsetTiming.HLAreportPeriod</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Total number of updates sent by the joined federate" in XML and "Total number of times the
+                     Update Attribute Values † service has successfully been invoked by the joined federate (as opposed
+                     to the number of instance attribute values that have been updated by the joined federate).
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAinteractionsReceived</name>
+                  <dataType>HLAcount</dataType>
+                  <updateType>Periodic</updateType>
+                  <updateCondition>HLAsetTiming.HLAreportPeriod</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Total number of interactions received by the joined federate.</semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAinteractionsSent</name>
+                  <dataType>HLAcount</dataType>
+                  <updateType>Periodic</updateType>
+                  <updateCondition>HLAsetTiming.HLAreportPeriod</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Total number of interactions sent by the joined federate. This information shall reflect
+                     related DDM usage.
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAobjectInstancesThatCanBeDeleted</name>
+                  <dataType>HLAcount</dataType>
+                  <updateType>Periodic</updateType>
+                  <updateCondition>HLAsetTiming.HLAreportPeriod</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Total number of object instances whose HLAprivilegeToDeleteObject attribute is owned by the
+                     joined federate
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAobjectInstancesUpdated</name>
+                  <dataType>HLAcount</dataType>
+                  <updateType>Periodic</updateType>
+                  <updateCondition>HLAsetTiming.HLAreportPeriod</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Total number of object instances for which the joined federate has invoked the Update
+                     Attribute Values service.
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAobjectInstancesReflected</name>
+                  <dataType>HLAcount</dataType>
+                  <updateType>Periodic</updateType>
+                  <updateCondition>HLAsetTiming.HLAreportPeriod</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Total number of object instances for which the joined federate has had a Reflect Attribute
+                     Values service invocation.
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAobjectInstancesDeleted</name>
+                  <dataType>HLAcount</dataType>
+                  <updateType>Periodic</updateType>
+                  <updateCondition>HLAsetTiming.HLAreportPeriod</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Total number of times the Delete Object Instance service was invoked by the joined federate
+                     since the federate joined the federation
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAobjectInstancesRemoved</name>
+                  <dataType>HLAcount</dataType>
+                  <updateType>Periodic</updateType>
+                  <updateCondition>HLAsetTiming.HLAreportPeriod</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Total number of times the Remove Object Instance service was invoked for the joined
+                     federate since the federate joined the federation.
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAobjectInstancesRegistered</name>
+                  <dataType>HLAcount</dataType>
+                  <updateType>Periodic</updateType>
+                  <updateCondition>HLAsetTiming.HLAreportPeriod</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Total number of times the Register Object Instance or Register Object Instance with Region
+                     service were invoked by the joined federate since the federate joined the federation.
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAobjectInstancesDiscovered</name>
+                  <dataType>HLAcount</dataType>
+                  <updateType>Periodic</updateType>
+                  <updateCondition>HLAsetTiming.HLAreportPeriod</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Total number of times the Discover Object Instance † service was invoked for the joined
+                     federate since the federate joined the federation.The value of the HLAobjectInstancesDiscovered
+                     attribute shall include multiple invocations of the Discover Object Instance † service for a given
+                     object instance that may occur as a result of invocation of the Local Delete Object Instance
+                     service at a federate.
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAtimeGrantedTime</name>
+                  <dataType>HLAmsec</dataType>
+                  <updateType>Periodic</updateType>
+                  <updateCondition>HLAsetTiming.HLAreportPeriod</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Wall clock time duration that the federate has spent in the Time Granted state since the
+                     last update of this attribute. When the HLAtimeGrantedTime and the HLAtimeAdvancingTime attributes
+                     are initially updated, their values shall be the wall-clock time duration that the federate has
+                     spent in the state since the federate has been joined to the federation execution.
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAtimeAdvancingTime</name>
+                  <dataType>HLAmsec</dataType>
+                  <updateType>Periodic</updateType>
+                  <updateCondition>HLAsetTiming.HLAreportPeriod</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Wall clock time duration that the federate has spent in the Time Advancing state since the
+                     last update of this attribute. When the HLAtimeGrantedTime and the HLAtimeAdvancingTime attributes
+                     are initially updated, their values shall be the wall-clock time duration that the federate has
+                     spent in the state since the federate has been joined to the federation execution.
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAconveyRegionDesignatorSets</name>
+                  <dataType>HLAswitch</dataType>
+                  <updateType>Conditional</updateType>
+                  <updateCondition>Whenever the HLAmanager.HLAfederate.HLAfederate.HLAadjust.HLAsetSwitches interaction
+                     is sent to successfully change the value of the HLAconveyRegionDesignatorSets parameter.
+                  </updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Value of joined federate's Convey Region Designator Sets Switch. Updated when value of
+                     switch changes
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAconveyProducingFederate</name>
+                  <dataType>HLAswitch</dataType>
+                  <updateType>Conditional</updateType>
+                  <updateCondition>Whenever the HLAmanager.HLAfederate.HLAfederate.HLAadjust.HLAsetSwitches interaction
+                     is sent to successfully change the value of the HLAconveyProducingFederate parameter.
+                  </updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <dimensions>
+                     <dimension>HLAfederate</dimension>
+                  </dimensions>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Value of joined federate's Convey Producing Federate Switch. Updated when value of switch
+                     changes
+                  </semantics>
+               </attribute>
+            </objectClass>
+            <objectClass>
+               <name>HLAfederation</name>
+               <sharing>Publish</sharing>
+               <semantics>This object class shall contain RTI state variables relating to a federation execution. The
+                  RTI shall publish it and shall register one object instance for the federation execution. The RTI
+                  shall respond to the invocation, by any federate, of the Request Attribute Value Update service for
+                  this object class or for any instance attribute of an object instance of this class by supplying
+                  values via the normal instance attribute update mechanism, regardless of whether the attribute has a
+                  data type of static or conditional. In addition to its responsibility to update attributes of object
+                  instances of this class when those updates are explicitly requested, the RTI shall automatically
+                  update instance attributes of object instances of this class according to the update policy of the
+                  attribute, which is determined by the update type of the class attribute in Table 6. Those attributes
+                  that have an update type of Conditional shall have update conditions as defined in the Table 6.
+               </semantics>
+               <attribute>
+                  <name>HLAfederationName</name>
+                  <dataType>HLAunicodeString</dataType>
+                  <updateType>Static</updateType>
+                  <updateCondition>NA</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Name of the federation to which the joined federate belongs</semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAfederatesInFederation</name>
+                  <dataType>HLAhandleList</dataType>
+                  <updateType>Conditional</updateType>
+                  <updateCondition>Federate joins or resigns</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Identifiers of joined federates that are joined to the federation</semantics>
+               </attribute>
+               <attribute>
+                  <name>HLARTIversion</name>
+                  <dataType>HLAunicodeString</dataType>
+                  <updateType>Static</updateType>
+                  <updateCondition>NA</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Version of the RTI software</semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAMIMdesignator</name>
+                  <dataType>HLAunicodeString</dataType>
+                  <updateType>Static</updateType>
+                  <updateCondition>NA</updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Designator associated with the MIM specified in the Create Federation Execution service
+                     invocation. In case the RTI has supplied the standard MIM, the designator shall be
+                     “HLAstandardMIM”.
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAFOMmoduleDesignatorList</name>
+                  <dataType>HLAmoduleDesignatorList</dataType>
+                  <updateType>Conditional</updateType>
+                  <updateCondition>Whenever new FOM modules are added by Create Federation Execution and Join Federation
+                     Execution service invocations.
+                  </updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>FOM Module designators for the federation as specified in the Create Federation Execution
+                     service and Join Federation Execution invocations. If several identical FOM modules are provided
+                     only the designator for the first of these FOM modules shall be added to the list.
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAcurrentFDD</name>
+                  <dataType>HLAunicodeString</dataType>
+                  <updateType>Conditional</updateType>
+                  <updateCondition>Whenever the Current FOM subset is modified by Create Federation Execution and Join
+                     Federation Execution service invocations.
+                  </updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>The Current FDD realized as a result of antecedent successful Create Federation Execution
+                     and Join Federation Execution service invocations.
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAtimeImplementationName</name>
+                  <dataType>HLAunicodeString</dataType>
+                  <updateType>Static</updateType>
+                  <updateCondition>N/A
+                  </updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Name of the time implementation as supplied to the Create Federation Execution service when
+                     the federation was created.
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAlastSaveName</name>
+                  <dataType>HLAunicodeString</dataType>
+                  <updateType>Conditional</updateType>
+                  <updateCondition>Whenever Federation Saved service is successfully invoked with a save-success
+                     indicator of successful
+                  </updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Name associated with the last federation state save (null if no saves have occurred)
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAlastSaveTime</name>
+                  <dataType>HLAlogicalTime</dataType>
+                  <updateType>Conditional</updateType>
+                  <updateCondition>Whenever Federation Saved service is successfully invoked with a save-success
+                     indicator of successful
+                  </updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Logical time at which the last federation state save occurred. If the last save was not a
+                     timed save, then the HLAlastSaveTime attribute value shall be an empty (zero-length) HLAlogicalTime
+                     array to indicate that the value of the HLAlastSaveTime attribute is undefined. If no timed saves
+                     have occurred the value shall be an empty (zero-length) HLAlogicalTime array.
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAnextSaveName</name>
+                  <dataType>HLAunicodeString</dataType>
+                  <updateType>Conditional</updateType>
+                  <updateCondition>Whenever Request Federation Save service is successfully invoked
+                  </updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Name associated with the next federation state save (null if no saves are scheduled)
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAnextSaveTime</name>
+                  <dataType>HLAlogicalTime</dataType>
+                  <updateType>Conditional</updateType>
+                  <updateCondition>Whenever Request Federation Save service is successfully invoked
+                  </updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Logical time at which the next federation state timed save is scheduled. If no timed saves
+                     are scheduled the value shall be an empty (zero-length) HLAlogicalTime array.
+                  </semantics>
+               </attribute>
+               <attribute>
+                  <name>HLAautoProvide</name>
+                  <dataType>HLAswitch</dataType>
+                  <updateType>Conditional</updateType>
+                  <updateCondition>Whenever the HLAmanager.HLAfederate.HLAfederation.HLAadjust.HLAsetSwitches
+                     interaction is sent to successfully change the value of the HLAautoProvide parameter.
+                  </updateCondition>
+                  <ownership>NoTransfer</ownership>
+                  <sharing>Publish</sharing>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Value of federation-wide Auto-Provide Switch. Updated when value of switch changes
+                  </semantics>
+               </attribute>
+            </objectClass>
+         </objectClass>
+      </objectClass>
+   </objects>
+   <interactions>
+      <interactionClass>
+         <name>HLAinteractionRoot</name>
+         <sharing>Neither</sharing>
+         <transportation>HLAreliable</transportation>
+         <order>TimeStamp</order>
+         <interactionClass>
+            <name>HLAmanager</name>
+            <sharing>Neither</sharing>
+            <transportation>HLAreliable</transportation>
+            <order>Receive</order>
+            <semantics>Root class of MOM interactions</semantics>
+            <interactionClass>
+               <name>HLAfederate</name>
+               <sharing>Neither</sharing>
+               <transportation>HLAreliable</transportation>
+               <order>Receive</order>
+               <semantics>Root class of MOM interactions that deal with a specific joined federate</semantics>
+               <parameter>
+                  <name>HLAfederate</name>
+                  <dataType>HLAhandle</dataType>
+                  <semantics>Handle of the joined federate that was provided when joining.</semantics>
+               </parameter>
+               <interactionClass>
+                  <name>HLAadjust</name>
+                  <sharing>Neither</sharing>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Permit a joined federate to adjust the RTI statevariables associated with another joined
+                     federate
+                  </semantics>
+                  <interactionClass>
+                     <name>HLAsetTiming</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Adjust the time period between updates of the HLAmanager.HLAfederate object instance for
+                        the specified joined federate. If this interaction is never sent, the RTI shall not perform
+                        periodic updates
+                     </semantics>
+                     <parameter>
+                        <name>HLAreportPeriod</name>
+                        <dataType>HLAseconds</dataType>
+                        <semantics>Number of seconds between updates of instance attribute values of the HLAfederate
+                           object instance (A zero value causes periodic updates to cease). If no interaction of class
+                           HLAmanager.HLAfederate.HLAadjust.HLAsetTiming has been sent, then no periodic updates of MOM
+                           attribute values shall be generated.
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAmodifyAttributeState</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Modify the ownership state of an attribute of an object instance for the specified
+                        joined federate. If the interaction is used to give ownership of the instance attribute to the
+                        specified joined federate and another joined federate currently owns the instance attribute, the
+                        owning joined federate shall be divested of ownership of the instance attribute before ownership
+                        is granted to the specified joined federate. No notification of change of ownership of the
+                        instance attribute shall be provided to either joined federate. In order for ownership of the
+                        instance attribute to be granted to the specified joined federate, the following conditions
+                        shall be true: - The specified joined federate knows about the object instance. - The specified
+                        joined federate is publishing the corresponding class attribute at the known class of the
+                        specified object instance at that joined federate. - The specified instance attribute is not
+                        owned by the RTI (i.e., it is not a predefined attribute of a MOM object class). If one or more
+                        of the above conditions are not met, then the interaction shall have no effect and an error
+                        shall be reported via an interaction of class HLAmanager. HLAfederate.HLAreport.
+                        HLAreportMOMexception.
+                     </semantics>
+                     <parameter>
+                        <name>HLAobjectInstance</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Handle of the object instance whose attribute state is being changed
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAattribute</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Handle of the instance attribute whose state is being changed</semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAattributeState</name>
+                        <dataType>HLAownership</dataType>
+                        <semantics>New state for the attribute of the object instance</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAsetServiceReporting</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Specify whether to report service invocations to or from the specified joined federate
+                        via HLAmanager.HLAfederate.HLAreport.HLAreportServiceInvocation interactions (enable or disable
+                        Service-Reporting). If the specified joined federate is subscribed to the
+                        HLAmanager.HLAfederate.HLAreport.HLAreportServiceInvocation interaction, all attempts to enable
+                        service reporting for that joined federate by sending an
+                        HLAmanager.HLAfederate.HLAadjust.HLAsetServiceReporting interaction with an HLAreportingState
+                        parameter value of HLAtrue shall fail and be reported via the normal MOM interaction failure
+                        means.
+                     </semantics>
+                     <parameter>
+                        <name>HLAreportingState</name>
+                        <dataType>HLAboolean</dataType>
+                        <semantics>Whether the RTI should report service invocations (default = HLAfalse)
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAsetExceptionReporting</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Specify whether the RTI shall report service invocation exceptions via
+                        HLAmanager.HLAfederate.HLAreport. HLAreportException interactions
+                     </semantics>
+                     <parameter>
+                        <name>HLAreportingState</name>
+                        <dataType>HLAboolean</dataType>
+                        <semantics>Whether the RTI should report exceptions (default = HLAfalse)</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAsetSwitches</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Set the values of joined federate specific switches. A joined federate may send
+                        individual declared parameters of this subclass.
+                     </semantics>
+                     <parameter>
+                        <name>HLAconveyRegionDesignatorSets</name>
+                        <dataType>HLAswitch</dataType>
+                        <semantics>Set the joined federate's Convey Region Designator Sets Switch to the provided value.
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAconveyProducingFederate</name>
+                        <dataType>HLAswitch</dataType>
+                        <semantics>Set the joined federate's Convey Producing Federate Switch to the provided value.
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+               </interactionClass>
+               <interactionClass>
+                  <name>HLArequest</name>
+                  <sharing>Neither</sharing>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Permit a federate to request RTI data about another federate</semantics>
+                  <interactionClass>
+                     <name>HLArequestPublications</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Request that the RTI send report interactions that contain the publication data of a
+                        joined federate. It shall result in one interaction of class HLAmanager. HLAfederate.HLAreport.
+                        HLAreportInteractionPublication and one interaction of class HLAmanager.HLAfederate.
+                        HLAreport.HLAreportObjectClassPublication for each object class published. If the joined
+                        federate is published to no object classes then one of class
+                        HLAmanager.HLAfederate.HLAreport.HLAreportObjectClassPublication shall be sent as a NULL
+                        response with the HLAobjectClassCount parameter having a value of 0.
+                     </semantics>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLArequestSubscriptions</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Request that the RTI send report interactions that contain the subscription data of a
+                        joined federate. It shall result in one interaction of class
+                        HLAmanager.HLAfederate.HLAreport.HLAreportInteractionSubscription and one interaction of class
+                        HLAmanager.HLAfederate.HLAreport.HLAreportObjectClassSubscription for each different combination
+                        of (object class, passive subscription indicator) values that are subscribed. If the joined
+                        federate is subscribed to no object classes, then one interaction of class
+                        HLAmanager.HLAfederate.HLAreport.HLAreportObjectClassSubscription shell be sent as a NULL
+                        response with the HLAobjectClassCount parameter having a value of 0.
+                     </semantics>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLArequestObjectInstancesThatCanBeDeleted</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Request that the RTI send a report interaction that contains the object instances that
+                        can be deleted at a joined federate. It shall result in one interaction of class
+                        HLAmanager.HLAfederate.HLAreport.HLAreportObjectInstancesThatCanBeDeleted.
+                     </semantics>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLArequestObjectInstancesUpdated</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Request that the RTI send a report interaction that contains the object instance
+                        updating responsibility of a joined federate. It shall result in one interaction of class
+                        HLAmanager.HLAfederate.HLAreport.HLAreportObjectInstancesUpdated.
+                     </semantics>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLArequestObjectInstancesReflected</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Request that the RTI send a report interaction that contains the object instances for
+                        which a joined federate has had a Reflect Attribute Values service invocation. It shall result
+                        in one interaction ofclass HLAmanager.HLAfederate.HLAreport.HLAreportObjectInstancesReflected.
+                     </semantics>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLArequestUpdatesSent</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Request that the RTI send a report interaction that contains the number of updates that
+                        a joined federate has generated. It shall result in one interaction of class
+                        HLAmanager.HLAfederate.HLAreport.HLAreportUpdatesSent for each transportation type.
+                     </semantics>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLArequestInteractionsSent</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Request that the RTI send a report interaction that contains the number of interactions
+                        that a joined federate has generated. This count shall include interactions sent with region. It
+                        shall result in one interaction of class
+                        HLAmanager.HLAfederate.HLAreport.HLAreportInteractionsSent for each transportation type.
+                     </semantics>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLArequestReflectionsReceived</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Request that the RTI send a report interaction that contains the number of reflections
+                        that a joined federate has received. It shall result in one interaction of class
+                        HLAmanager.HLAfederate.HLAreport.HLAreportReflectionsReceived for each transportation type.
+                     </semantics>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLArequestInteractionsReceived</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Request that the RTI send a report interaction that contains the number of interactions
+                        that a joined federate has received. It shall result in one interaction of class
+                        HLAmanager.HLAfederate.HLAreport.HLAreportInteractionsReceived for each transportation type.
+                     </semantics>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLArequestObjectInstanceInformation</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Request that the RTI send a report interaction that contains the information that a
+                        joined federate maintains on a single object instance. It shall result in one interaction of
+                        class HLAmanager.HLAfederate.HLAreport.HLAreportObjectInstanceInformation
+                     </semantics>
+                     <parameter>
+                        <name>HLAobjectInstance</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Handle of the object instance for which information is being requested
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLArequestFOMmoduleData</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Requests that the RTI shall send a report interaction with the content of the specified
+                        FOM module that was specified by the federate. The FOM module is indicated by the order number
+                        in the federates HLAFOMmoduleDesignatorList attribute.
+                     </semantics>
+                     <parameter>
+                        <name>HLAFOMmoduleIndicator</name>
+                        <dataType>HLAindex</dataType>
+                        <semantics>Indicates order number of requested FOM module</semantics>
+                     </parameter>
+                  </interactionClass>
+               </interactionClass>
+               <interactionClass>
+                  <name>HLAreport</name>
+                  <sharing>Neither</sharing>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Report RTI data about a joined federate. The RTI shall send these interactions in response
+                     to interactions of class HLAmanager.HLAfederate.HLArequest that correspond to services that are
+                     normally invoked by federates.
+                  </semantics>
+                  <interactionClass>
+                     <name>HLAreportObjectClassPublication</name>
+                     <sharing>Publish</sharing>
+                     <dimensions>
+                        <dimension>HLAfederate</dimension>
+                     </dimensions>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>The interaction shall be sent by the RTI in response to an interaction of class
+                        HLAmanager.HLAfederate.HLArequest.HLArequestPublications. It shall report the attributes of one
+                        object class published by the joined federate. One of these interactions shall be sent for each
+                        object class containing attributes that are published by the joined federate. If the joined
+                        federate is published to no object classes then a single interaction shall be sent as a NULL
+                        response with the HLAobjectClassCount parameter having a value of 0.
+                     </semantics>
+                     <parameter>
+                        <name>HLAnumberOfClasses</name>
+                        <dataType>HLAcount</dataType>
+                        <semantics>The number of object classes for which the joined federate publishes attributes. This
+                           parameter shall be 0 in a NULL response.
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAobjectClass</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>The object class whose publication is being reported. This parameter shall be omitted
+                           in a NULL response.
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAattributeList</name>
+                        <dataType>HLAhandleList</dataType>
+                        <semantics>List of handles of HLAobjectClass attributes that the joined federate is publishing.
+                           This parameter shall be omitted in a NULL response.
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAreportInteractionPublication</name>
+                     <sharing>Publish</sharing>
+                     <dimensions>
+                        <dimension>HLAfederate</dimension>
+                     </dimensions>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>The interaction shall be sent by the RTI in response to an interaction of class
+                        HLAmanager.HLAfederate.HLArequest.HLArequestPublications. It shall report the interaction
+                        classes published by the joined federate. If the joined federate is published to no interaction
+                        classes, then a single interaction shall be sent as a NULL response with the
+                        HLAinteractionClassList parameter having an undefined value (i.e. 0 length array).
+                     </semantics>
+                     <parameter>
+                        <name>HLAinteractionClassList</name>
+                        <dataType>HLAhandleList</dataType>
+                        <semantics>List of interaction classes that the joined federate is publishing. This parameter
+                           shall be an empty list in a NULL response.
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAreportObjectClassSubscription</name>
+                     <sharing>Publish</sharing>
+                     <dimensions>
+                        <dimension>HLAfederate</dimension>
+                     </dimensions>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>The interaction shall be sent by the RTI in response to an interaction of class
+                        HLAmanager.HLAfederate.HLArequest.HLArequestSubscriptions. It shall report the attributes of one
+                        object class subscribed to by the joined federate. One of these interactions shall be sent for
+                        each object class that is subscribed by the joined federate. This information shall reflect
+                        related DDM usage. If joined federate has no subscribed object classes, then a single
+                        interaction shall be sent as a NULL response with the HLAnumberOfClasses parameter having a
+                        value of 0.
+                     </semantics>
+                     <parameter>
+                        <name>HLAnumberOfClasses</name>
+                        <dataType>HLAcount</dataType>
+                        <semantics>The number of object class and passive indicator combinations for which the joined
+                           federate subscribes to attributes. This information shall reflect related DDM usage. This
+                           parameter shall be 0 in a NULL response.
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAobjectClass</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>The object class whose subscription is being reported. This parameter shall be
+                           omitted in a NULL response.
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAactive</name>
+                        <dataType>HLAboolean</dataType>
+                        <semantics>Whether the subscription is active. This parameter shall be omitted in a NULL
+                           response.
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAmaxUpdateRate</name>
+                        <dataType>HLAupdateRateName</dataType>
+                        <semantics>Name of the maximum subscribed update rate. This parameter shall be omitted in a NULL
+                           response.
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAattributeList</name>
+                        <dataType>HLAhandleList</dataType>
+                        <semantics>List of handles of class attributes to which the joined federate is subscribing. This
+                           parameter shall be omitted in a NULL response.
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAreportInteractionSubscription</name>
+                     <sharing>Publish</sharing>
+                     <dimensions>
+                        <dimension>HLAfederate</dimension>
+                     </dimensions>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>The interaction shall be sent by the RTI in response to an interaction of class
+                        HLAmanager.HLAfederate.HLArequest.HLArequestSubscriptions. It shall report the interaction
+                        classes subscribed to by the joined federate. This information shall reflect related DDM usage.
+                        If the joined federate has no subscribed interaction classes, then a single interaction shall be
+                        sent as a NULL response with the HLAinteractionClassList parameter having an undefined value.
+                     </semantics>
+                     <parameter>
+                        <name>HLAinteractionClassList</name>
+                        <dataType>HLAinteractionSubList</dataType>
+                        <semantics>List of interaction class/subscription type pairs. Each pair consists of the handle
+                           of an interaction class that the joined federate is subscribed to and whether the joined
+                           federate is actively subscribing. This information shall reflect related DDM usage. This
+                           parameter shall be an empty list in a NULL response.
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAreportObjectInstancesThatCanBeDeleted</name>
+                     <sharing>Publish</sharing>
+                     <dimensions>
+                        <dimension>HLAfederate</dimension>
+                     </dimensions>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>The interaction shall be sent by the RTI in response to an interaction of class
+                        HLAmanager.HLAfederate.HLArequest.HLArequestObject InstancesThatCanBeDeleted. It shall report
+                        the number of object instances (by registered class of the object instances) whose
+                        HLAprivilegeToDeleteObject attributes are owned by the joined federate.
+                     </semantics>
+                     <parameter>
+                        <name>HLAobjectInstanceCounts</name>
+                        <dataType>HLAobjectClassBasedCounts</dataType>
+                        <semantics>A list of object instance counts. Each object instance count consists of an object
+                           class handle and the number of object instances of that class. This parameter shall be an
+                           empty list in a NULL response.
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAreportObjectInstancesUpdated</name>
+                     <sharing>Publish</sharing>
+                     <dimensions>
+                        <dimension>HLAfederate</dimension>
+                     </dimensions>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>The interaction shall be sent by the RTI in response to an interaction of class
+                        HLAmanager.HLAfederate.HLArequest.HLArequestObjectInstancessUpdated. It shall report the number
+                        of object instances (by registered class of the object instances) for which the joined federate
+                        has successfully invoked the Update Attribute Values service. If the joined federate has no
+                        object instances that are updated for a given transport type then a single interaction shall be
+                        sent as a NULL response with the HLAobjectInstanceCounts parameter having an undefined value.
+                     </semantics>
+                     <parameter>
+                        <name>HLAobjectInstanceCounts</name>
+                        <dataType>HLAobjectClassBasedCounts</dataType>
+                        <semantics>List of object instance counts. Each object instance count consists of an object
+                           class handle and the number of object instances of that class. This parameter shall be an
+                           empty list in a NULL response.
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAreportObjectInstancesReflected</name>
+                     <sharing>Publish</sharing>
+                     <dimensions>
+                        <dimension>HLAfederate</dimension>
+                     </dimensions>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>The interaction shall be sent by the RTI in response to an interaction of class
+                        HLAmanager.HLAfederate.HLArequest.HLArequestObjectInstancesReflected. It shall report the number
+                        of object instances (by registered class of the object instances) for which the joined federate
+                        has had a Reflect Attribute Values service invocation. If the joined federate has no object
+                        instances that are reflected for a given transport type, then a single interaction shall be sent
+                        as a NULL response with the HLAobjectInstanceCounts parameter having an undefined value.
+                     </semantics>
+                     <parameter>
+                        <name>HLAobjectInstanceCounts</name>
+                        <dataType>HLAobjectClassBasedCounts</dataType>
+                        <semantics>List of object instance counts. Each object instance count consists of an object
+                           class handle and the number of object instances of that class. This parameter shall be an
+                           empty list in a NULL response.
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAreportUpdatesSent</name>
+                     <sharing>Publish</sharing>
+                     <dimensions>
+                        <dimension>HLAfederate</dimension>
+                     </dimensions>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>The interaction shall be sent by the RTI in response to an interaction of class
+                        HLAmanager.HLAfederate.HLArequest.HLArequestUpdatesSent. It shall report the number of updates
+                        sent (by registered class of the object instances of the updates) by the joined federate since
+                        the beginning of the federation execution. One interaction of this class shall be sent by the
+                        RTI for each transportation type used. If the joined federate has no updates sent for a given
+                        transportation type, then a single interaction shall be sent as a NULL response with the
+                        HLAupdateCounts parameter having an undefined value.
+                     </semantics>
+                     <parameter>
+                        <name>HLAtransportation</name>
+                        <dataType>HLAtransportationName</dataType>
+                        <semantics>Transportation type used in sending updates</semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAupdateCounts</name>
+                        <dataType>HLAobjectClassBasedCounts</dataType>
+                        <semantics>List of update counts. Each update count consists of an object class handle and the
+                           number of updates sent of that class. If no updates of instance attributes of any object
+                           instances of any class for a given transportation type have been sent, then the RTI shall
+                           send a HLAmanager.HLAfederate. HLAreport.HLAreportUpdatesSent interaction for that
+                           transportation type. However, no HLAobjectClassBasedCount elements at all shall appear in the
+                           HLAobjectClassBased Count array for that interaction of that transportation type. In other
+                           words, the HLAreportUpdatesSent interaction that is sent for that transportation type will
+                           have an empty HLAobjectClassBasedCount array. If no updates of instance attributes of any
+                           object instances of a given class for a given transportation type have been sent, then no
+                           HLAobjectClassBasedCount element for that object class shall be in the
+                           HLAobjectClassBasedCount array of the HLAmanager.HLAfederate.HLAreport.HLAreportUpdatesSent
+                           interaction for that transportation type. This parameter shall be an empty list in a NULL
+                           response for the given transportation type.
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAreportReflectionsReceived</name>
+                     <sharing>Publish</sharing>
+                     <dimensions>
+                        <dimension>HLAfederate</dimension>
+                     </dimensions>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>The interaction shall be sent by the RTI in response to an interaction of class
+                        HLAmanager.HLAfederate.HLArequest.HLArequestReflectionsReceived. It shall report the number of
+                        reflections received (by registered class of the object instances of the reflects) by the joined
+                        federate since the beginning of the federation execution. One interaction of this class shall be
+                        sent by the RTI for each transportation type used. If the joined federate has no reflections
+                        received for a given transportation type, then a single interaction shall be sent as a NULL
+                        response with the HLAreflectCounts parameter having an undefined value.
+                     </semantics>
+                     <parameter>
+                        <name>HLAtransportation</name>
+                        <dataType>HLAtransportationName</dataType>
+                        <semantics>Transportation type used in receiving reflections</semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAreflectCounts</name>
+                        <dataType>HLAobjectClassBasedCounts</dataType>
+                        <semantics>List of reflection counts. Each reflection count consists of an object class handle
+                           and the number of reflections received of that class. If no reflects of instance attributes
+                           of any object instances of any class for a given transportation type have been received, then
+                           the RTI shall send a HLAmanager.HLAfederate.HLAreport.HLAreportReflectionsReceived
+                           interaction for that transportation type. However, no HLAobjectClassBasedCount elements at
+                           all shall appear in the HLAobjectClassBasedCount array for that interaction of that
+                           transportation type. In other words, the HLAreportReflectionsReceived interaction that is
+                           sent for that transportation type shall have an empty HLAobjectClassBasedCount array. If no
+                           reflects of instance attributes of any object instances of a given class for a given
+                           transportation type have been received, then no HLAobjectClassBasedCount element for that
+                           object class shall be in the HLAobjectClassBasedCount array of the HLAmanager.
+                           HLAfederate.HLAreport.HLAreportReflectionsReceived interaction for that transportation type.
+                           This parameter shall be an empty list in a NULL response for the given transportation type.
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAreportInteractionsSent</name>
+                     <sharing>Publish</sharing>
+                     <dimensions>
+                        <dimension>HLAfederate</dimension>
+                     </dimensions>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>The interaction shall be sent by the RTI in response to an interaction of class
+                        HLAmanager.HLAfederate.HLArequest.HLArequestInteractionsSent. It shall report the number of
+                        interactions sent (by sent class of the interactions) by the joined federate since the beginning
+                        of the federation execution. This count shall include interactions sent with region. One
+                        interaction of this class shall be sent by the RTI for each transportation type used. If the
+                        joined federate has no interactions that are sent for a given transportation type then a single
+                        interaction shall be sent as a NULL response with the HLAinteractionCounts parameter having an
+                        undefined value.
+                     </semantics>
+                     <parameter>
+                        <name>HLAtransportation</name>
+                        <dataType>HLAtransportationName</dataType>
+                        <semantics>Transportation type used in sending interactions</semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAinteractionCounts</name>
+                        <dataType>HLAinteractionCounts</dataType>
+                        <semantics>List of interaction counts. Each interaction count consists of an interaction class
+                           handle and the number of interactions of that class. This information shall reflect related
+                           DDM usage. This parameter shall be an empty list in a NULL response for the given
+                           transportation type.
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAreportInteractionsReceived</name>
+                     <sharing>Publish</sharing>
+                     <dimensions>
+                        <dimension>HLAfederate</dimension>
+                     </dimensions>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>The interaction shall be sent by the RTI in response to an interaction of
+                        classHLAmanager.HLAfederate.HLArequest. HLArequestInteractionsReceived. It shall report the
+                        number of interactions received (by sent class of the interactions) by the joined federate since
+                        the beginning of the federation execution. One interaction of this class shall be sent by the
+                        RTI for each transportation type used. If the joined federate has no interactions that are
+                        received for a given transportation type, then a single interaction shall be sent as a NULL
+                        response with the HLAinteractionCounts parameter having an undefined value.
+                     </semantics>
+                     <parameter>
+                        <name>HLAtransportation</name>
+                        <dataType>HLAtransportationName</dataType>
+                        <semantics>Transportation type used in receiving interactions</semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAinteractionCounts</name>
+                        <dataType>HLAinteractionCounts</dataType>
+                        <semantics>List of interaction counts. Each interaction count consists of an interaction class
+                           handle and the number of interactions of that class. This parameter shall be an empty list in
+                           a NULL response for the given transportation type.
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAreportObjectInstanceInformation</name>
+                     <sharing>Publish</sharing>
+                     <dimensions>
+                        <dimension>HLAfederate</dimension>
+                     </dimensions>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>The interaction shall be sent by the RTI in response to an interaction of class
+                        HLAmanager.HLAfederate.HLArequest.HLArequestObjectInstanceInformation. It shall report on a
+                        single object instance and portray the instance attributes of that object instance that are
+                        owned by the joined federate, the registered class of the object instance, and the known class
+                        of the object instance at that joined federate. If the joined federate does not know the object
+                        instance, a single interaction shall be sent as a NULL response with the
+                        HLAownedInstanceAttributeList parameter having an undefined value.
+                     </semantics>
+                     <parameter>
+                        <name>HLAobjectInstance</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Handle of the object instance for which the interaction was sent</semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAownedInstanceAttributeList</name>
+                        <dataType>HLAhandleList</dataType>
+                        <semantics>List of the handles of all instance attributes, of the object instance, owned by the
+                           joined federate. This parameter shall be an empty list in a NULL response.
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAregisteredClass</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Handle of the registered class of the object instance. This parameter shall be
+                           omitted in a NULL response.
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAknownClass</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Handle of the known class of the object instance at the joined federate. This
+                           parameter shall be omitted in a NULL response.
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAreportException</name>
+                     <sharing>Publish</sharing>
+                     <dimensions>
+                        <dimension>HLAfederate</dimension>
+                     </dimensions>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>The interaction shall be sent by the RTI when an exception occurs as the result of a
+                        service invocation at the indicated joined federate. This interaction shall be sent only if the
+                        last HLAmanager.HLAfederate.HLAadjust.HLAsetExceptionReporting interaction changing the
+                        HLAreportingState parameter sets the parameter to HLAtrue, for the indicated joined federate.
+                     </semantics>
+                     <parameter>
+                        <name>HLAservice</name>
+                        <dataType>HLAunicodeString</dataType>
+                        <semantics>In the case in which the HLAreportMOMexception interaction is sent by the RTI because
+                           a service interaction (an interaction that imitates a federate's invocation of an HLA
+                           service) was sent and not all of the service's preconditions are met, the value of this
+                           parameter shall be the name of the HLAinteractionRoot.HLA.Manager.HLAfederate.HLAservice
+                           interaction that was sent. In the case in which the HLAreportMOMexception interaction is sent
+                           by the RTI because a MOM interaction without all of the necessary parameters was sent, the
+                           value of this parameter shall be the name of the class of the interaction that was sent. The
+                           name of the interaction class provided shall always be fully qualified, as defined in the
+                           OMT, so as to avoid potential ambiguities.
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAexception</name>
+                        <dataType>HLAunicodeString</dataType>
+                        <semantics>Textual depiction of the exception.</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAreportServiceInvocation</name>
+                     <sharing>Publish</sharing>
+                     <dimensions>
+                        <dimension>HLAfederate</dimension>
+                        <dimension>HLAserviceGroup</dimension>
+                     </dimensions>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>This interaction shall be sent by the RTI whenever an HLA service is invoked, either by
+                        the indicated joined federate or by the RTI at the indicated joined federate, and
+                        Service-Reporting is Enabled for the indicated joined federate. This interaction shall always
+                        contain the arguments supplied by the service invoker. If the service invocation was successful,
+                        the interaction also shall contain the value returned to the invoker (if the service returns a
+                        value); otherwise, the interaction also shall contain an indication of the exception that was
+                        raised to the invoker.
+                     </semantics>
+                     <parameter>
+                        <name>HLAservice</name>
+                        <dataType>HLAunicodeString</dataType>
+                        <semantics>Textual name of the service</semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAsuccessIndicator</name>
+                        <dataType>HLAboolean</dataType>
+                        <semantics>Whether the service invocation was successful. Exception values are returned along
+                           with HLAfalse value
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAsuppliedArguments</name>
+                        <dataType>HLAargumentList</dataType>
+                        <semantics>Textual depiction of the arguments supplied in the service invocation
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAreturnedArguments</name>
+                        <dataType>HLAargumentList</dataType>
+                        <semantics>Textual depiction of the argument returned by the service invocation. The list is
+                           null if the service does not normally return a value or if HLAsuccessIndicator is HLAfalse.
+                           Each returned argument is an element on the list. The number of returned arguments depends
+                           upon the service narrative and not any particular API and services may have more than one
+                           returned argument.
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAexception</name>
+                        <dataType>HLAunicodeString</dataType>
+                        <semantics>Textual depiction of the exception raised by this service invocation (null if
+                           HLAsuccessIndicator is HLAtrue)
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAserialNumber</name>
+                        <dataType>HLAcount</dataType>
+                        <semantics>This is a per-joined federate serial number that shall start at zero and shall
+                           increment by 1 for each HLAmanager.HLAfederate.HLAreport HLAreportServiceInvocation
+                           interaction that represents service invocations to or from the respective joined federate.
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAreportMOMexception</name>
+                     <sharing>Publish</sharing>
+                     <dimensions>
+                        <dimension>HLAfederate</dimension>
+                     </dimensions>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>The interaction shall be sent by the RTI when one the following occurs: a MOM
+                        interaction without all the necessary parameters is sent or an interaction that imitates a
+                        federate's invocation of an HLA service is sent and not all of the service's pre-conditions are
+                        met.
+                     </semantics>
+                     <parameter>
+                        <name>HLAservice</name>
+                        <dataType>HLAunicodeString</dataType>
+                        <semantics>Name of the service interaction that had a problem or raised the exception
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAexception</name>
+                        <dataType>HLAunicodeString</dataType>
+                        <semantics>Textual depiction of the problem/exception</semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAparameterError</name>
+                        <dataType>HLAboolean</dataType>
+                        <semantics>HLAtrue if there was an incorrect number of interaction parameters or a parameter was
+                           incorrectly formatted, HLAfalse otherwise
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAreportFederateLost</name>
+                     <sharing>Publish</sharing>
+                     <dimensions>
+                        <dimension>HLAfederate</dimension>
+                     </dimensions>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>This MOM interaction shall be sent when a federate has been lost from the federation due
+                        to a fault.
+                     </semantics>
+                     <parameter>
+                        <name>HLAfederateName</name>
+                        <dataType>HLAunicodeString</dataType>
+                        <semantics>Name of the lost joined federate
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAtimeStamp</name>
+                        <dataType>HLAlogicalTime</dataType>
+                        <semantics>Last-known-good timestamp to which the lost joined federate was granted
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAfaultDescription</name>
+                        <dataType>HLAunicodeString</dataType>
+                        <semantics>Human-readable description of the fault
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAreportFOMmoduleData</name>
+                     <sharing>Publish</sharing>
+                     <dimensions>
+                        <dimension>HLAfederate</dimension>
+                     </dimensions>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>The interaction shall be sent by the RTI in response to an interaction of class
+                        HLAmanager.HLAfederate.HLArequest.HLArequestFOMmoduleData. It shall report the content of the
+                        specified FOM module for the federate.
+                     </semantics>
+                     <parameter>
+                        <name>HLAFOMmoduleIndicator</name>
+                        <dataType>HLAindex</dataType>
+                        <semantics>Indicates order number of reported FOM module</semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAFOMmoduleData</name>
+                        <dataType>HLAunicodeString</dataType>
+                        <semantics>Contents of the reported FOM module</semantics>
+                     </parameter>
+                  </interactionClass>
+               </interactionClass>
+               <interactionClass>
+                  <name>HLAservice</name>
+                  <sharing>Neither</sharing>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>The interaction class shall be acted upon by the RTI. These interactions shall invoke HLA
+                     services on behalf of another joined federate. They shall cause the RTI to react as if the service
+                     has been invoked by that other joined federate. If exceptions arise as a result of the use of these
+                     interactions, they shall be reported via the HLAmanager.HLAfederate.HLAreport.HLAreportMOMexception
+                     interaction to all joined federates that subscribe to this interaction. There are two ways an error
+                     can occur: the sending federate does not provide all the required arguments as parameters or the
+                     preconditions of the spoofed service are not met. Each type of error is reported via the
+                     HLAMOMreportMOMexception. NOTE - These interactions shall have the potential to disrupt normal
+                     federation execution and should be used with great care.
+                  </semantics>
+                  <interactionClass>
+                     <name>HLAresignFederationExecution</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Cause the joined federate to resign from the federation execution. A joined federate
+                        shall be able to send this interaction anytime.
+                     </semantics>
+                     <parameter>
+                        <name>HLAresignAction</name>
+                        <dataType>HLAresignAction</dataType>
+                        <semantics>Action that the RTI is to take in conjunction with the resignation
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAsynchronizationPointAchieved</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Mimic the federate's report of achieving a synchronization point.</semantics>
+                     <parameter>
+                        <name>HLAlabel</name>
+                        <dataType>HLAunicodeString</dataType>
+                        <semantics>Label associated with the synchronization point</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAfederateSaveBegun</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Mimic the federate's report of starting a save</semantics>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAfederateSaveComplete</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Mimic the joined federate's report of completion of a federate save. A joined federate
+                        shall be able to send this interaction during a federate save.
+                     </semantics>
+                     <parameter>
+                        <name>HLAsuccessIndicator</name>
+                        <dataType>HLAboolean</dataType>
+                        <semantics>Whether the federate save was successful</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAfederateRestoreComplete</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Mimic the joined federate's report of completion of a restore. A joined federate shall
+                        be able to send this interaction during a federation restore.
+                     </semantics>
+                     <parameter>
+                        <name>HLAsuccessIndicator</name>
+                        <dataType>HLAboolean</dataType>
+                        <semantics>Whether the restore was successful</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLApublishObjectClassAttributes</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Set the joined federate's publication status of attributes of an object class
+                     </semantics>
+                     <parameter>
+                        <name>HLAobjectClass</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Object class for which the joined federate's publication shall change
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAattributeList</name>
+                        <dataType>HLAhandleList</dataType>
+                        <semantics>List of handles of attributes of HLAobjectClass, that the joined federate shall now
+                           publish
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAunpublishObjectClassAttributes</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Cause the joined federate no longer to publish attributes of an object class
+                     </semantics>
+                     <parameter>
+                        <name>HLAobjectClass</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Object class for which the joined federate's unpublication shall change
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAattributeList</name>
+                        <dataType>HLAhandleList</dataType>
+                        <semantics>List of handles of attributes of HLAobjectClass, that the joined federate shall now
+                           unpublish
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLApublishInteractionClass</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Set the joined federate's publication status of an interaction class</semantics>
+                     <parameter>
+                        <name>HLAinteractionClass</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Interaction class that the joined federate shall publish</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAunpublishInteractionClass</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Cause the joined federate no longer to publish an interaction class</semantics>
+                     <parameter>
+                        <name>HLAinteractionClass</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Interaction class that the joined federate shall no longer publish
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAsubscribeObjectClassAttributes</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Set the joined federate's subscription status of attributes of an object class
+                     </semantics>
+                     <parameter>
+                        <name>HLAobjectClass</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Object class for which the joined federate's subscription shall change
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAattributeList</name>
+                        <dataType>HLAhandleList</dataType>
+                        <semantics>List of handles of attributes of HLAobjectClass to which the joined federate shall
+                           now subscribe
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAactive</name>
+                        <dataType>HLAboolean</dataType>
+                        <semantics>Whether the subscription is active</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAunsubscribeObjectClassAttributes</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Cause the joined federate no longer to subscribe to attributes of an object class
+                     </semantics>
+                     <parameter>
+                        <name>HLAobjectClass</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Object class for which the joined federate's subscription shall change
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAattributeList</name>
+                        <dataType>HLAhandleList</dataType>
+                        <semantics>List of handles of attributes of HLAobjectClass to which the joined federate shall
+                           now unsubscribe
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAsubscribeInteractionClass</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Set the joined federate's subscription status to an interaction class.
+                     </semantics>
+                     <parameter>
+                        <name>HLAinteractionClass</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Interaction class to which the federate shall subscribe</semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAactive</name>
+                        <dataType>HLAboolean</dataType>
+                        <semantics>Whether the subscription is active</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAunsubscribeInteractionClass</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Cause the joined federate no longer to subscribe to an interaction class
+                     </semantics>
+                     <parameter>
+                        <name>HLAinteractionClass</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Interaction class to which the joined federate will no longer be subscribed
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAdeleteObjectInstance</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Cause an object instance to be deleted from the federation.</semantics>
+                     <parameter>
+                        <name>HLAobjectInstance</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Handle of the object instance that is to be deleted</semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAtag</name>
+                        <dataType>HLAopaqueData</dataType>
+                        <semantics>Tag associated with the deletion</semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAtimeStamp</name>
+                        <dataType>HLAlogicalTime</dataType>
+                        <semantics>Time stamp of the deletion (optional)</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAlocalDeleteObjectInstance</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Inform the RTI that it shall treat the specified object instance as if the joined
+                        federate did not know about the object instance.
+                     </semantics>
+                     <parameter>
+                        <name>HLAobjectInstance</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Handle of the object instance that is to be deleted</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLArequestAttributeTransportationTypeChange</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Request a change of the transportation type used by the joined federate when sending
+                        attributes belonging to the object instance
+                     </semantics>
+                     <parameter>
+                        <name>HLAobjectInstance</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Handle of the object instance whose attribute transportation type is to be changed
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAattributeList</name>
+                        <dataType>HLAhandleList</dataType>
+                        <semantics>List of the handles of instance attributes whose transportation type is to be changed
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAtransportation</name>
+                        <dataType>HLAtransportationName</dataType>
+                        <semantics>Transportation type to be used for updating instance attributes in the list
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLArequestInteractionTransportationTypeChange</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Request a change of the transportation type used by the joined federate when sending a
+                        class of interaction
+                     </semantics>
+                     <parameter>
+                        <name>HLAinteractionClass</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Interaction class whose transportation type is changed by this service invocation
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAtransportation</name>
+                        <dataType>HLAtransportationName</dataType>
+                        <semantics>Transportation type to be used for sending the interaction class</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAunconditionalAttributeOwnershipDivestiture</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Cause the ownership of attributes of an object instance to be unconditionally divested
+                        by the joined federate
+                     </semantics>
+                     <parameter>
+                        <name>HLAobjectInstance</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Handle of the object instance whose attributes' ownership is to be divested
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAattributeList</name>
+                        <dataType>HLAhandleList</dataType>
+                        <semantics>List of handles of instance attributes belonging to HLAobjectInstance whose ownership
+                           is to be divested by the joined federate
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAenableTimeRegulation</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Cause the joined federate to begin regulating the logical time of other joined federates
+                     </semantics>
+                     <parameter>
+                        <name>HLAlookahead</name>
+                        <dataType>HLAtimeInterval</dataType>
+                        <semantics>Lookahead to be used by the joined federate while regulating other joined federates
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAdisableTimeRegulation</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Cause the joined federate to cease regulating the logical time of other joined federates
+                     </semantics>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAenableTimeConstrained</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Cause the logical time of the joined federate to begin being constrained by the logical
+                        times of other joined federates
+                     </semantics>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAdisableTimeConstrained</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Cause the logical time of the joined federate to cease being constrained by the logical
+                        times of other joined federates
+                     </semantics>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAtimeAdvanceRequest</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Request an advance of the joined federate's logical time on behalf of the joined
+                        federate, and release zero or more messages for delivery to the joined federate
+                     </semantics>
+                     <parameter>
+                        <name>HLAtimeStamp</name>
+                        <dataType>HLAlogicalTime</dataType>
+                        <semantics>Time stamp requested</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAtimeAdvanceRequestAvailable</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Request an advance of the joined federate's logical time, on behalf of the joined
+                        federate, and release zero or more messages for delivery to the joined federate
+                     </semantics>
+                     <parameter>
+                        <name>HLAtimeStamp</name>
+                        <dataType>HLAlogicalTime</dataType>
+                        <semantics>Time stamp requested</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAnextMessageRequest</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Request the logical time of the joined federate to be advanced to the time stamp of the
+                        next TSO message that shall be delivered to the joined federate, provided that the message shall
+                        have a time stamp no greater than the logical time specified in the request, and release zero or
+                        more messages for delivery to the joined federate.
+                     </semantics>
+                     <parameter>
+                        <name>HLAtimeStamp</name>
+                        <dataType>HLAlogicalTime</dataType>
+                        <semantics>Time stamp requested</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAnextMessageRequestAvailable</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Request the logical time of the joined federate to be advanced to the time stamp of the
+                        next TSO message that shall be delivered to the joined federate, provided that the message shall
+                        have a time stamp no greater than the logical time specified in the request, and release zero or
+                        more messages for delivery to the joined federate.
+                     </semantics>
+                     <parameter>
+                        <name>HLAtimeStamp</name>
+                        <dataType>HLAlogicalTime</dataType>
+                        <semantics>Time stamp requested</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAflushQueueRequest</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Request the logical time of the joined federate to be advanced as far as possible,
+                        provided that the time stamp is less than or equal to the logical time specified in the request.
+                        All TSO and RO messages shall be delivered to the joined federate.
+                     </semantics>
+                     <parameter>
+                        <name>HLAtimeStamp</name>
+                        <dataType>HLAlogicalTime</dataType>
+                        <semantics>Time stamp requested</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAenableAsynchronousDelivery</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Cause the RTI to deliver RO messages to the joined federate at any wall-clock time, even
+                        if the joined federate is time-constrained.
+                     </semantics>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAdisableAsynchronousDelivery</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>When the joined federate is time-constrained, cause the RTI to deliver RO messages to
+                        the joined federate only when its time manager state is "Time Advancing".
+                     </semantics>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAmodifyLookahead</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Change the lookahead value used by the joined federate</semantics>
+                     <parameter>
+                        <name>HLAlookahead</name>
+                        <dataType>HLAtimeInterval</dataType>
+                        <semantics>New value for lookahead</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAchangeAttributeOrderType</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Change the order type used by the joined federate when sending attributes belonging to
+                        the object instance
+                     </semantics>
+                     <parameter>
+                        <name>HLAobjectInstance</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Handle of the object instance whose attribute order type is to be changed
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAattributeList</name>
+                        <dataType>HLAhandleList</dataType>
+                        <semantics>List of the handles of instance attributes whose order type is to be changed
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAsendOrder</name>
+                        <dataType>HLAorderType</dataType>
+                        <semantics>Order type to be used for sending the instance attribute list</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAchangeInteractionOrderType</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Change the order type used by the joined federate when sending a class of interaction
+                     </semantics>
+                     <parameter>
+                        <name>HLAinteractionClass</name>
+                        <dataType>HLAhandle</dataType>
+                        <semantics>Interaction class whose order type is changed by this service invocation
+                        </semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAsendOrder</name>
+                        <dataType>HLAorderType</dataType>
+                        <semantics>Order type to be used for sending the interaction class</semantics>
+                     </parameter>
+                  </interactionClass>
+               </interactionClass>
+            </interactionClass>
+            <interactionClass>
+               <name>HLAfederation</name>
+               <sharing>Neither</sharing>
+               <transportation>HLAreliable</transportation>
+               <order>Receive</order>
+               <semantics>Root class of MOM interactions that deal with a specific federation execution.
+               </semantics>
+               <interactionClass>
+                  <name>HLAadjust</name>
+                  <sharing>Neither</sharing>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Permit a federate to adjust the RTI state variables associated with a federation execution.
+                  </semantics>
+                  <interactionClass>
+                     <name>HLAsetSwitches</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Set the values of federation execution-wide switches. A joined federate may send
+                        individual declared parameters of this subclass.
+                     </semantics>
+                     <parameter>
+                        <name>HLAautoProvide</name>
+                        <dataType>HLAswitch</dataType>
+                        <semantics>Set the federation-wide Auto-Provide Switch to the provided value.
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+               </interactionClass>
+               <interactionClass>
+                  <name>HLArequest</name>
+                  <sharing>Neither</sharing>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Permit a federate to request RTI data about a specific federation execution
+                  </semantics>
+                  <interactionClass>
+                     <name>HLArequestSynchronizationPoints</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Request that the RTI send a report interaction that contains a list of all in-progress
+                        federation synchonization points. It shall result in one interaction class
+                        HLAmanager.HLAfederation.HLAreport.HLAreportSynchronizationPoints
+                     </semantics>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLArequestSynchronizationPointStatus</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Request that the RTI send a report interaction that contains a list that includes each
+                        federate (and its synchronization point status) that is associated with a particular
+                        synchronization point. It shall result in one interaction of class
+                        HLAmanager.HLAfederation.HLAreport.HLAreportSynchronizationPointStaus.
+                     </semantics>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLArequestFOMmoduleData</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Requests that the RTI shall send a report interaction with the content of the specified
+                        FOM module for the federation. The FOM module is indicated by the order number in the
+                        federations HLAFOMmoduleDesignatorList attribute.
+                     </semantics>
+                     <parameter>
+                        <name>HLAFOMmoduleIndicator</name>
+                        <dataType>HLAindex</dataType>
+                        <semantics>Indicates order number of requested FOM module</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLArequestMIMdata</name>
+                     <sharing>Subscribe</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>Requests that the RTI shall send a report interaction with the content of the MIM for
+                        the federation.
+                     </semantics>
+                  </interactionClass>
+               </interactionClass>
+               <interactionClass>
+                  <name>HLAreport</name>
+                  <sharing>Neither</sharing>
+                  <transportation>HLAreliable</transportation>
+                  <order>Receive</order>
+                  <semantics>Permit a federate to receive RTI data about a specific federation execution
+                  </semantics>
+                  <interactionClass>
+                     <name>HLAreportSynchronizationPoints</name>
+                     <sharing>Publish</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>The interaction shall be sent by the RTI in response to an interaction of class
+                        HLAmanager.HLAfederation.HLArequest.HLArequestSynchronizationPoints. It shall report the list of
+                        active synchronization points in the federation execution.
+                     </semantics>
+                     <parameter>
+                        <name>HLAsyncPoints</name>
+                        <dataType>HLAsynchPointList</dataType>
+                        <semantics>List of the in progress federation execution synchronization points
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAreportSynchronizationPointStatus</name>
+                     <sharing>Publish</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>The interaction shall be sent by the RTI in response to an interaction of class
+                        HLAmanager.HLAfederation. HLArequest.HLArequestSynchronizationPointStatus. It shall report the
+                        status of a particular synchronization point. This shall be a list that includes each federate
+                        (and its synchronization status) that is associated with a particular synchronization point.
+                     </semantics>
+                     <parameter>
+                        <name>HLAsyncPointName</name>
+                        <dataType>HLAunicodeString</dataType>
+                        <semantics>Name of a particular synchronization point</semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAsyncPointFederates</name>
+                        <dataType>HLAsynchPointFederateList</dataType>
+                        <semantics>List of each federate (and its synchronization status) associated with the particular
+                           synchronization point
+                        </semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAreportFOMmoduleData</name>
+                     <sharing>Publish</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>The interaction shall be sent by the RTI in response to an interaction of class
+                        HLAmanager.HLAfederation.HLArequest.HLArequestFOMmoduleData. It shall report the content of the
+                        specified FOM module for the federation.
+                     </semantics>
+                     <parameter>
+                        <name>HLAFOMmoduleIndicator</name>
+                        <dataType>HLAindex</dataType>
+                        <semantics>Indicates order number of reported FOM module</semantics>
+                     </parameter>
+                     <parameter>
+                        <name>HLAFOMmoduleData</name>
+                        <dataType>HLAunicodeString</dataType>
+                        <semantics>Contents of the reported FOM module</semantics>
+                     </parameter>
+                  </interactionClass>
+                  <interactionClass>
+                     <name>HLAreportMIMdata</name>
+                     <sharing>Publish</sharing>
+                     <transportation>HLAreliable</transportation>
+                     <order>Receive</order>
+                     <semantics>The interaction shall be sent by the RTI in response to an interaction of class
+                        HLAmanager.HLAfederation.HLArequest.HLArequest MIMData. It shall report the content of the MIM
+                        for the federation.
+                     </semantics>
+                     <parameter>
+                        <name>HLAMIMdata</name>
+                        <dataType>HLAunicodeString</dataType>
+                        <semantics>Contents of the reported MIM</semantics>
+                     </parameter>
+                  </interactionClass>
+               </interactionClass>
+            </interactionClass>
+         </interactionClass>
+      </interactionClass>
+   </interactions>
+   <dimensions>
+      <dimension notes="MOM1">
+         <name>HLAfederate</name>
+         <dataType>HLAnormalizedFederateHandle</dataType>
+         <normalization>Normalize Federate Handle service</normalization>
+         <value>Excluded</value>
+      </dimension>
+      <dimension>
+         <name>HLAserviceGroup</name>
+         <dataType>HLAnormalizedServiceGroup</dataType>
+         <upperBound>7</upperBound>
+         <normalization>Normalize Service Group service</normalization>
+         <value>Excluded</value>
+      </dimension>
+   </dimensions>
+   <transportations>
+      <transportation>
+         <name>HLAreliable</name>
+         <reliable>Yes</reliable>
+         <semantics>Provide reliable delivery of data in the sense that TCP/IP delivers its data reliably</semantics>
+      </transportation>
+      <transportation>
+         <name>HLAbestEffort</name>
+         <reliable>No</reliable>
+         <semantics>Make an effort to deliver data in the sense that UDP provides best-effort delivery</semantics>
+      </transportation>
+   </transportations>
+   <dataTypes>
+      <basicDataRepresentations>
+         <basicData>
+            <name>HLAinteger16BE</name>
+            <size>16</size>
+            <interpretation>Integer in the range [-2^15, 2^15 - 1]</interpretation>
+            <endian>Big</endian>
+            <encoding>16-bit two's complement signed integer. The most significant bit contains the sign.</encoding>
+         </basicData>
+         <basicData>
+            <name>HLAinteger32BE</name>
+            <size>32</size>
+            <interpretation>Integer in the range [-2^31, 2^31 - 1]</interpretation>
+            <endian>Big</endian>
+            <encoding>32-bit two's complement signed integer. The most significant bit contains the sign.</encoding>
+         </basicData>
+         <basicData>
+            <name>HLAinteger64BE</name>
+            <size>64</size>
+            <interpretation>Integer in the range [-2^63, 2^63 - 1]</interpretation>
+            <endian>Big</endian>
+            <encoding>64-bit two's complement signed integer first. The most significant bit contains the sign.
+            </encoding>
+         </basicData>
+         <basicData>
+            <name>HLAfloat32BE</name>
+            <size>32</size>
+            <interpretation>Single-precision floating point number</interpretation>
+            <endian>Big</endian>
+            <encoding>32-bit IEEE normalized single-precision format. See IEEE Std 754-1985</encoding>
+         </basicData>
+         <basicData>
+            <name>HLAfloat64BE</name>
+            <size>64</size>
+            <interpretation>Double-precision floating point number</interpretation>
+            <endian>Big</endian>
+            <encoding>64-bit IEEE normalized double-precision format. See IEEE Std 754-1985</encoding>
+         </basicData>
+         <basicData>
+            <name>HLAoctetPairBE</name>
+            <size>16</size>
+            <interpretation>16-bit value</interpretation>
+            <endian>Big</endian>
+            <encoding>Assumed to be portable among devices.</encoding>
+         </basicData>
+         <basicData>
+            <name>HLAinteger16LE</name>
+            <size>16</size>
+            <interpretation>Integer in the range [-2^15, 2^15 - 1]</interpretation>
+            <endian>Little</endian>
+            <encoding>16-bit two's complement signed integer. The most significant bit contains the sign.</encoding>
+         </basicData>
+         <basicData>
+            <name>HLAinteger32LE</name>
+            <size>32</size>
+            <interpretation>Integer in the range [-2^31, 2^31 - 1]</interpretation>
+            <endian>Little</endian>
+            <encoding>32-bit two's complement signed integer. The most significant bit contains the sign.</encoding>
+         </basicData>
+         <basicData>
+            <name>HLAinteger64LE</name>
+            <size>64</size>
+            <interpretation>Integer in the range [-2^63, 2^63 - 1]</interpretation>
+            <endian>Little</endian>
+            <encoding>64-bit two's complement signed integer first. The most significant bit contains the sign.
+            </encoding>
+         </basicData>
+         <basicData>
+            <name>HLAfloat32LE</name>
+            <size>32</size>
+            <interpretation>Single-precision floating point number</interpretation>
+            <endian>Little</endian>
+            <encoding>32-bit IEEE normalized single-precision format. See IEEE Std 754-1985</encoding>
+         </basicData>
+         <basicData>
+            <name>HLAfloat64LE</name>
+            <size>64</size>
+            <interpretation>Double-precision floating point number</interpretation>
+            <endian>Little</endian>
+            <encoding>64-bit IEEE normalized double-precision format. See IEEE Std 754-1985</encoding>
+         </basicData>
+         <basicData>
+            <name>HLAoctetPairLE</name>
+            <size>16</size>
+            <interpretation>16-bit value</interpretation>
+            <endian>Little</endian>
+            <encoding>Assumed to be portable among hardware devices.</encoding>
+         </basicData>
+         <basicData>
+            <name>HLAoctet</name>
+            <size>8</size>
+            <interpretation>8-bit value</interpretation>
+            <endian>Big</endian>
+            <encoding>Assumed to be portable among hardware devices.</encoding>
+         </basicData>
+      </basicDataRepresentations>
+      <simpleDataTypes>
+         <simpleData>
+            <name>HLAASCIIchar</name>
+            <representation>HLAoctet</representation>
+            <units>NA</units>
+            <resolution>NA</resolution>
+            <accuracy>NA</accuracy>
+            <semantics>Standard ASCII character (see ANSI Std x3.4-1986)</semantics>
+         </simpleData>
+         <simpleData>
+            <name>HLAunicodeChar</name>
+            <representation>HLAoctetPairBE</representation>
+            <units>NA</units>
+            <resolution>NA</resolution>
+            <accuracy>NA</accuracy>
+            <semantics>Unicode UTF-16 character (see The Unicode Standard, Version 3.0)</semantics>
+         </simpleData>
+         <simpleData>
+            <name>HLAbyte</name>
+            <representation>HLAoctet</representation>
+            <units>NA</units>
+            <resolution>NA</resolution>
+            <accuracy>NA</accuracy>
+            <semantics>Uninterpreted 8-bit byte</semantics>
+         </simpleData>
+         <simpleData>
+            <name>HLAcount</name>
+            <representation>HLAinteger32BE</representation>
+            <units>NA</units>
+            <resolution>NA</resolution>
+            <accuracy>NA</accuracy>
+            <semantics>NA</semantics>
+         </simpleData>
+         <simpleData>
+            <name>HLAseconds</name>
+            <representation>HLAinteger32BE</representation>
+            <units>s</units>
+            <resolution>NA</resolution>
+            <accuracy>NA</accuracy>
+            <semantics>NA</semantics>
+         </simpleData>
+         <simpleData>
+            <name>HLAmsec</name>
+            <representation>HLAinteger32BE</representation>
+            <units>ms</units>
+            <resolution>NA</resolution>
+            <accuracy>NA</accuracy>
+            <semantics>NA</semantics>
+         </simpleData>
+         <simpleData>
+            <name>HLAnormalizedFederateHandle</name>
+            <representation>HLAinteger32BE</representation>
+            <units>NA</units>
+            <resolution>NA</resolution>
+            <accuracy>NA</accuracy>
+            <semantics>The type of the normalized value of a federate handle as returned by the Normalize Federate
+               Handle service. The value is appropriate for defining the range of the HLAfederate dimension for regions
+               with this dimension.
+            </semantics>
+         </simpleData>
+         <simpleData>
+            <name>HLAindex</name>
+            <representation>HLAinteger32BE</representation>
+            <units>NA</units>
+            <resolution>NA</resolution>
+            <accuracy>NA</accuracy>
+            <semantics>NA</semantics>
+         </simpleData>
+         <simpleData>
+            <name>HLAinteger64Time</name>
+            <representation>HLAinteger64BE</representation>
+            <units>NA</units>
+            <resolution>1</resolution>
+            <accuracy>NA</accuracy>
+            <semantics>Standardized 64 bit integer time</semantics>
+         </simpleData>
+         <simpleData>
+            <name>HLAfloat64Time</name>
+            <representation>HLAfloat64BE</representation>
+            <units>NA</units>
+            <resolution>4.9E-308</resolution>
+            <accuracy>NA</accuracy>
+            <semantics>Standardized 64 bit float time</semantics>
+         </simpleData>
+      </simpleDataTypes>
+      <enumeratedDataTypes>
+         <enumeratedData>
+            <name>HLAboolean</name>
+            <representation>HLAinteger32BE</representation>
+            <semantics>Standard boolean type</semantics>
+            <enumerator>
+               <name>HLAfalse</name>
+               <value>0</value>
+            </enumerator>
+            <enumerator>
+               <name>HLAtrue</name>
+               <value>1</value>
+            </enumerator>
+         </enumeratedData>
+         <enumeratedData>
+            <name>HLAfederateState</name>
+            <representation>HLAinteger32BE</representation>
+            <semantics>State of the federate</semantics>
+            <enumerator>
+               <name>ActiveFederate</name>
+               <value>1</value>
+            </enumerator>
+            <enumerator>
+               <name>FederateSaveInProgress</name>
+               <value>3</value>
+            </enumerator>
+            <enumerator>
+               <name>FederateRestoreInProgress</name>
+               <value>5</value>
+            </enumerator>
+         </enumeratedData>
+         <enumeratedData>
+            <name>HLAtimeState</name>
+            <representation>HLAinteger32BE</representation>
+            <semantics>State of time advancement</semantics>
+            <enumerator>
+               <name>TimeGranted</name>
+               <value>0</value>
+            </enumerator>
+            <enumerator>
+               <name>TimeAdvancing</name>
+               <value>1</value>
+            </enumerator>
+         </enumeratedData>
+         <enumeratedData>
+            <name>HLAownership</name>
+            <representation>HLAinteger32BE</representation>
+            <semantics>NA</semantics>
+            <enumerator>
+               <name>Unowned</name>
+               <value>0</value>
+            </enumerator>
+            <enumerator>
+               <name>Owned</name>
+               <value>1</value>
+            </enumerator>
+         </enumeratedData>
+         <enumeratedData>
+            <name>HLAresignAction</name>
+            <representation>HLAinteger32BE</representation>
+            <semantics>Action to be performed by RTI in conjunction with resignation</semantics>
+            <enumerator>
+               <name>DivestOwnership</name>
+               <value>1</value>
+            </enumerator>
+            <enumerator>
+               <name>DeleteObjectInstances</name>
+               <value>2</value>
+            </enumerator>
+            <enumerator>
+               <name>CancelPendingAcquisitions</name>
+               <value>3</value>
+            </enumerator>
+            <enumerator>
+               <name>DeleteObjectInstancesThenDivestOwnership</name>
+               <value>4</value>
+            </enumerator>
+            <enumerator>
+               <name>CancelPendingAcquisitionsThenDeleteObjectInstancesThenDivestOwnership</name>
+               <value>5</value>
+            </enumerator>
+            <enumerator>
+               <name>NoAction</name>
+               <value>6</value>
+            </enumerator>
+         </enumeratedData>
+         <enumeratedData>
+            <name>HLAorderType</name>
+            <representation>HLAinteger32BE</representation>
+            <semantics>Order type to be used for sending attributes or interactions</semantics>
+            <enumerator>
+               <name>Receive</name>
+               <value>0</value>
+            </enumerator>
+            <enumerator>
+               <name>TimeStamp</name>
+               <value>1</value>
+            </enumerator>
+         </enumeratedData>
+         <enumeratedData>
+            <name>HLAswitch</name>
+            <representation>HLAinteger32BE</representation>
+            <semantics>NA</semantics>
+            <enumerator>
+               <name>Enabled</name>
+               <value>1</value>
+            </enumerator>
+            <enumerator>
+               <name>Disabled</name>
+               <value>0</value>
+            </enumerator>
+         </enumeratedData>
+         <enumeratedData>
+            <name>HLAsynchPointStatus</name>
+            <representation>HLAinteger32BE</representation>
+            <semantics>Joined federate synchronization point status</semantics>
+            <enumerator>
+               <name>NoActivity</name>
+               <value>0</value>
+            </enumerator>
+            <enumerator>
+               <name>AttemptingToRegisterSynchPoint</name>
+               <value>1</value>
+            </enumerator>
+            <enumerator>
+               <name>MovingToSynchPoint</name>
+               <value>2</value>
+            </enumerator>
+            <enumerator>
+               <name>WaitingForRestOfFederation</name>
+               <value>3</value>
+            </enumerator>
+         </enumeratedData>
+         <enumeratedData>
+            <name>HLAnormalizedServiceGroup</name>
+            <representation>HLAinteger32BE</representation>
+            <semantics>Service group identifier</semantics>
+            <enumerator>
+               <name>FederationManagement</name>
+               <value>0</value>
+            </enumerator>
+            <enumerator>
+               <name>DeclarationManagement</name>
+               <value>1</value>
+            </enumerator>
+            <enumerator>
+               <name>ObjectManagement</name>
+               <value>2</value>
+            </enumerator>
+            <enumerator>
+               <name>OwnershipManagement</name>
+               <value>3</value>
+            </enumerator>
+            <enumerator>
+               <name>TimeManagement</name>
+               <value>4</value>
+            </enumerator>
+            <enumerator>
+               <name>DataDistributionManagement</name>
+               <value>5</value>
+            </enumerator>
+            <enumerator>
+               <name>SupportServices</name>
+               <value>6</value>
+            </enumerator>
+         </enumeratedData>
+      </enumeratedDataTypes>
+      <arrayDataTypes>
+         <arrayData>
+            <name>HLAASCIIstring</name>
+            <dataType>HLAASCIIchar</dataType>
+            <cardinality>Dynamic</cardinality>
+            <encoding>HLAvariableArray</encoding>
+            <semantics>ASCII string representation</semantics>
+         </arrayData>
+         <arrayData>
+            <name>HLAunicodeString</name>
+            <dataType>HLAunicodeChar</dataType>
+            <cardinality>Dynamic</cardinality>
+            <encoding>HLAvariableArray</encoding>
+            <semantics>Unicode string representation</semantics>
+         </arrayData>
+         <arrayData>
+            <name>HLAopaqueData</name>
+            <dataType>HLAbyte</dataType>
+            <cardinality>Dynamic</cardinality>
+            <encoding>HLAvariableArray</encoding>
+            <semantics>Uninterpreted sequence of bytes</semantics>
+         </arrayData>
+         <arrayData>
+            <name>HLAtoken</name>
+            <dataType>HLAbyte</dataType>
+            <cardinality>0</cardinality>
+            <encoding>HLAfixedArray</encoding>
+         </arrayData>
+         <arrayData>
+            <name>HLAhandle</name>
+            <dataType>HLAbyte</dataType>
+            <cardinality>Dynamic</cardinality>
+            <encoding>HLAvariableArray</encoding>
+            <semantics>Encoded value of a handle. The encoding is based on the type of handle</semantics>
+         </arrayData>
+         <arrayData>
+            <name>HLAtransportationName</name>
+            <dataType>HLAunicodeChar</dataType>
+            <cardinality>Dynamic</cardinality>
+            <encoding>HLAvariableArray</encoding>
+            <semantics>String whose legal value shall be a name from any row in the OMT transportation table (IEEE Std
+               1516.2-2010)
+            </semantics>
+         </arrayData>
+         <arrayData>
+            <name>HLAupdateRateName</name>
+            <dataType>HLAunicodeChar</dataType>
+            <cardinality>Dynamic</cardinality>
+            <encoding>HLAvariableArray</encoding>
+            <semantics>String whose legal value shall be a name from any row in the OMT update rate table (IEEE Std
+               1516.2-2010)
+            </semantics>
+         </arrayData>
+         <arrayData>
+            <name>HLAlogicalTime</name>
+            <dataType>HLAbyte</dataType>
+            <cardinality>Dynamic</cardinality>
+            <encoding>HLAvariableArray</encoding>
+            <semantics>An encoded logical time. An empty array shall indicate that the values is not defined
+            </semantics>
+         </arrayData>
+         <arrayData>
+            <name>HLAtimeInterval</name>
+            <dataType>HLAbyte</dataType>
+            <cardinality>Dynamic</cardinality>
+            <encoding>HLAvariableArray</encoding>
+            <semantics>An encoded logical time interval. An empty array shall indicate that the values is not defined
+            </semantics>
+         </arrayData>
+         <arrayData>
+            <name>HLAhandleList</name>
+            <dataType>HLAhandle</dataType>
+            <cardinality>Dynamic</cardinality>
+            <encoding>HLAvariableArray</encoding>
+            <semantics>List of encoded handles</semantics>
+         </arrayData>
+         <arrayData>
+            <name>HLAinteractionSubList</name>
+            <dataType>HLAinteractionSubscription</dataType>
+            <cardinality>Dynamic</cardinality>
+            <encoding>HLAvariableArray</encoding>
+            <semantics>List of interaction subscription indicators</semantics>
+         </arrayData>
+         <arrayData>
+            <name>HLAargumentList</name>
+            <dataType>HLAunicodeString</dataType>
+            <cardinality>Dynamic</cardinality>
+            <encoding>HLAvariableArray</encoding>
+            <semantics>List of arguments</semantics>
+         </arrayData>
+         <arrayData>
+            <name>HLAobjectClassBasedCounts</name>
+            <dataType>HLAobjectClassBasedCount</dataType>
+            <cardinality>Dynamic</cardinality>
+            <encoding>HLAvariableArray</encoding>
+            <semantics>List of counts of various items based on object class. In all MOM interactions that have a
+               parameter of datatype HLAobjectClassBased- Counts, if an HLAobjectClassBasedCount element of the
+               HLAobjectClassBasedCounts array would have a value (object class, 0), the HLAobjectClassBasedCount
+               element shall not be present in the HLAobjectClassBasedCounts array. In other words, only HLAobject-
+               ClassBasedCount elements that have positive counts shall be present in an HLAobjectClassBasedCounts
+               array. From this, it follows that if all object class counts have a zero value, then the HLAobjectClass-
+               BasedCounts array shall not have any elements in it; it shall be an empty HLAobjectClassBasedCounts
+               array.
+            </semantics>
+         </arrayData>
+         <arrayData>
+            <name>HLAinteractionCounts</name>
+            <dataType>HLAinteractionCount</dataType>
+            <cardinality>Dynamic</cardinality>
+            <encoding>HLAvariableArray</encoding>
+            <semantics>List of interaction counts. In all MOM interactions that have a parameter of datatype
+               HLAinteractionCounts, if an HLAinteractionCount element of the HLAinteractionCounts array would have a
+               value (interaction class, 0), the HLAinteractionCount element shall not be present in the
+               HLAinteractionCounts array. In other words, only HLAinteractionCount elements that have positive counts
+               shall be present in an HLAinteractionCounts array. From this, it follows that if all interaction class
+               counts have a zero value, then the HLAinteractionCounts array shall not have any elements in it; it shall
+               be an empty HLAinteractionCounts array.
+            </semantics>
+         </arrayData>
+         <arrayData>
+            <name>HLAsynchPointList</name>
+            <dataType>HLAunicodeString</dataType>
+            <cardinality>Dynamic</cardinality>
+            <encoding>HLAvariableArray</encoding>
+            <semantics>List of names of synchronization points.</semantics>
+         </arrayData>
+         <arrayData>
+            <name>HLAsynchPointFederateList</name>
+            <dataType>HLAsynchPointFederate</dataType>
+            <cardinality>Dynamic</cardinality>
+            <encoding>HLAvariableArray</encoding>
+            <semantics>List of joined federates and the synchronization status of each.</semantics>
+         </arrayData>
+         <arrayData>
+            <name>HLAmoduleDesignatorList</name>
+            <dataType>HLAunicodeString</dataType>
+            <cardinality>Dynamic</cardinality>
+            <encoding>HLAvariableArray</encoding>
+            <semantics>List of designators of FOM modules.</semantics>
+         </arrayData>
+      </arrayDataTypes>
+      <fixedRecordDataTypes>
+         <fixedRecordData>
+            <name>HLAinteractionSubscription</name>
+            <encoding>HLAfixedRecord</encoding>
+            <semantics>Interaction subscription information</semantics>
+            <field>
+               <name>HLAinteractionClass</name>
+               <dataType>HLAhandle</dataType>
+               <semantics>Encoded interaction class handle</semantics>
+            </field>
+            <field>
+               <name>HLAactive</name>
+               <dataType>HLAboolean</dataType>
+               <semantics>Whether subscription is active (HLAtrue=active)</semantics>
+            </field>
+         </fixedRecordData>
+         <fixedRecordData>
+            <name>HLAobjectClassBasedCount</name>
+            <encoding>HLAfixedRecord</encoding>
+            <semantics>Object class and count of associated items</semantics>
+            <field>
+               <name>HLAobjectClass</name>
+               <dataType>HLAhandle</dataType>
+               <semantics>Encoded object class handle</semantics>
+            </field>
+            <field>
+               <name>HLAcount</name>
+               <dataType>HLAcount</dataType>
+               <semantics>Number of items</semantics>
+            </field>
+         </fixedRecordData>
+         <fixedRecordData>
+            <name>HLAinteractionCount</name>
+            <encoding>HLAfixedRecord</encoding>
+            <semantics>Count of interactions of a class</semantics>
+            <field>
+               <name>HLAinteractionClass</name>
+               <dataType>HLAhandle</dataType>
+               <semantics>Encoded interaction class handle</semantics>
+            </field>
+            <field>
+               <name>HLAinteractionCount</name>
+               <dataType>HLAcount</dataType>
+               <semantics>Number of interactions</semantics>
+            </field>
+         </fixedRecordData>
+         <fixedRecordData>
+            <name>HLAsynchPointFederate</name>
+            <encoding>HLAfixedRecord</encoding>
+            <semantics>A particular joined federate and its synchronization point status</semantics>
+            <field>
+               <name>HLAfederate</name>
+               <dataType>HLAhandle</dataType>
+               <semantics>Encoded joined federate handle</semantics>
+            </field>
+            <field>
+               <name>HLAfederateSynchStatus</name>
+               <dataType>HLAsynchPointStatus</dataType>
+               <semantics>Synchronization status of the particular joined federate</semantics>
+            </field>
+         </fixedRecordData>
+      </fixedRecordDataTypes>
+      <variantRecordDataTypes/>
+   </dataTypes>
+   <notes>
+      <note>
+         <label>MOM1</label>
+         <semantics>The value of the Dimension Upper Bound entry for the Federate dimension is RTI implementation
+            dependent.
+         </semantics>
+      </note>
+   </notes>
+
+   <!--
+    <switches>
+        <autoProvide isEnabled="true"/>
+        <conveyRegionDesignatorSets isEnabled="false"/>
+        <conveyProducingFederate isEnabled="false"/>
+        <attributeScopeAdvisory isEnabled="false"/>
+        <attributeRelevanceAdvisory isEnabled="false"/>
+        <objectClassRelevanceAdvisory isEnabled="false"/>
+        <interactionRelevanceAdvisory isEnabled="false"/>
+        <serviceReporting isEnabled="false"/>
+        <exceptionReporting isEnabled="false"/>
+        <delaySubscriptionEvaluation isEnabled="false"/>
+        <automaticResignAction resignAction="CancelThenDeleteThenDivest"/>
+    </switches>
+    -->
+</objectModel>

--- a/codebase/resources/testdata/hla/fomOverride/README.md
+++ b/codebase/resources/testdata/hla/fomOverride/README.md
@@ -1,0 +1,9 @@
+FOM Overriding Tests
+======================
+When configuring Disco, a user has the option of specifying a FOM overrides folder, that if used
+defines a folder from which FOM modules should be loaded instead of using the default RPR modules
+that are shipped within the JAR.
+
+This folder is used to support tests, and it is important that only the contained modules that are
+present are kept, as the tests will confirm the number of expected modules based on the module
+count (so adding or removing will break the tests) and on the specific file names.

--- a/codebase/resources/testdata/hla/fomOverride/RPR-Base_v2.0.xml
+++ b/codebase/resources/testdata/hla/fomOverride/RPR-Base_v2.0.xml
@@ -1,0 +1,1399 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<objectModel xsi:schemaLocation="http://standards.ieee.org/IEEE1516-2010 http://standards.ieee.org/downloads/1516/1516.2-2010/IEEE1516-DIF-2010.xsd" xmlns="http://standards.ieee.org/IEEE1516-2010" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelIdentification>
+        <name>SISO-STD-001.1-2015 - Real-time Platform Reference Base FOM Module</name>
+        <type>FOM</type>
+        <version>2.0</version>
+        <modificationDate>2015-08-10</modificationDate>
+        <securityClassification>Unclassified</securityClassification>
+        <purpose>The RPR FOM supports interoperability for real-time, platform oriented defense simulation.</purpose>
+        <applicationDomain>All domains</applicationDomain>
+        <description>This module provides a common base for RPR based FOM Modules. It contains common datatypes and the BaseEntity and EmbeddedSystem object class definitions.</description>
+        <useLimitation></useLimitation>
+        <poc>
+            <pocType>Primary author</pocType>
+            <pocName>RPR FOM Product Development Group</pocName>
+            <pocOrg>SISO - Simulation Interoperability Standards Organization</pocOrg>
+            <pocTelephone>+1 (407) 882-1348</pocTelephone>
+            <pocEmail>siso-help@sisostds.org</pocEmail>
+        </poc>
+        <reference>
+            <type>Dependency</type>
+            <identification>Real-time Platform Reference Enumerations FOM Module</identification>
+        </reference>
+        <reference>
+            <type>Text Document</type>
+            <identification>Standard for Guidance, Rationale, and Interoperability Modalities for the Real-time Platform Reference Federation Object Model (RPR FOM)
+SISO-STD-001-2015
+10 August 2015</identification>
+        </reference>
+        <reference>
+            <type>Text Document</type>
+            <identification>IEEE Standard for Distributed Interactive Simulation - Application Protocols
+IEEE Std 1278.1-1995
+September 21, 1995</identification>
+        </reference>
+        <reference>
+            <type>Text Document</type>
+            <identification>IEEE Standard for Distributed Interactive Simulation - Application Protocols
+IEEE Std 1278.1a-1998
+19 March 1998</identification>
+        </reference>
+        <other>Copyright © 2015 by the Simulation Interoperability Standards Organization, Inc.
+P.O. Box 781238
+Orlando, FL 32878-1238, USA
+All rights reserved.
+
+Schema and API: SISO hereby grants a general, royalty-free license to copy, distribute, display, and make derivative works from this material, for all purposes, provided that any use of the material contains the following attribution: “Reprinted with permission from SISO Inc.” Should a reader require additional information, contact the SISO Inc. Board of Directors.
+
+Documentation: SISO hereby grants a general, royalty-free license to copy, distribute, display, and make derivative works from this material, for noncommercial purposes, provided that any use of the material contains the following attribution: “Reprinted with permission from SISO Inc.” The material may not be used for a commercial purpose without express written permission from the SISO Inc. Board of Directors.
+
+SISO Inc. Board of Directors
+P.O. Box 781238
+Orlando, FL 32878-1238, USA
+</other>
+        <glyph type="png" height="64" width="64" alt="">iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAABaRJREFUeNrsWmtIU28Yn3Oat0xNGTo0kSDC+SExBcULosgcuMgLZKLoBBcpoiEofvGCeMP5YQjui5YIi/RDQRFhGCoVpCEaal5zOIV9EBRvef//6oXD/umO85yj88Ae2GFs73ve5/fcn/d97QICAgQCgZ2dnYBvdHx8jKfo4OBgeXlZwE+SSCRCBwcHAW8JzAsFPCcbABsAGwAbgFNTzLdv3woKCgIDAzMzM9+8ebO5uXlRCG7dunXMHa2trT1//jwmJoakdqFQSGWcwsLC/v7+3d1dDpcD85wBGB8fLysr8/X1JRyHhIS0tbXNzc11dXUlJSVR6fLOnTuVlZUjIyOHh4dXAsDW1lZPT49MJhOJRODP0dHx4cOH79+/39vbMx02MzPT0NBw7949AgP6uX//fmNj4/T0tNUAzM7OVlVVBQUFEZ78/PwqKip+/vxJMwV115cvX0pKSvz9/alaICEhob293WAwXBIAiPbdu3dpaWlOTk6EicjIyM7OTli/5S+BT79+/Rr+7e7uTl7i5uaWmpqq0+lWV1cvCsDS0lJzc3NwcDBZ0tXVNScnZ2hoiI01r6ysaLXa+Ph4YoEgHx+fvLw8yAjGyQ0A6P3Tp0/g9fr162SN27dv19XV6fV6DuPJxMRETU2NVCqlwiNCMIwNAtrf32cIAFaOSBIeHk5ior29PeIJXHZ7e/v4Ygi8DgwMPH36lHISLI3A1dTUxASAXC4nb4HsESJZRoxz0fr6em5uLqWNuLg4cwDoMjHlphADDAmeR7q4i24UP378+OjRo+7ubqJ2PF1cXJhk4vz8/P9VHUJhRESERqOB512E1I+Ojvr6+hBVyXJeXl4tLS0qlQrfFQoFExMqLS09FTNeDf2iLqBxLzasI7bCYhH08BfSNn5B1GYCoLq6mkbXsKvQ0FC1Wk1W4oR1ZIPi4uJfv35RAxCI8DssigmA1tZWYoL0dOPGjaysrA8fPvxTPpyLdWdnZ1gL4t4/w1AC4t/s7GwmADo6Oq5du2a5/6GAQ8FjKj9LWMcSyFyTk5OnDkZNjjFKpZIJgN7eXjr3N0Mwg4yMjLdv3/7+/ftU1hMTE6lC6PHjx2NjYzRoSTCFcpgAwGJUrcKA7t69W1tbS1mFKeuwzPT09O/fv59paUCI8UVFRUwAfP78WSwWs4zrKJmgkOTkZKrFSUlJ+fr1q4WugrmY9ezZM3MARDRrw7GgAaPRyAYAarJXr16RqIW2ASV3dHS05dMRGIixmRsgos/EMGiu9gDhUZD9eSci1dADENJrgKpAWRKCQWxsLIOJZ2rgjFqIKwCMiRUADjXAjBB2WZkQhz5gHQDIkdbVAGlxmAMgadW6GmDlA6QXs64GCABHR0deAiA+gOTNVw0QE2IFwLo+QJyYxxo4PDzc3d1lC4DaM7tkWllZefLkycbGhsNf4hmAly9fhoeH44nvYWFhgYGBDA840LBz4gbomy3c/V1eXkYLT5WANTU1Ozs7zPdGYYIPHjy4NAA6nU4ikZApUVFRIyMjHGzuIpb19/fL5XJLdigYAzAVPHReX19/sqVmu70+ODioUCiYwaAHYCr4uLg4+jaf7QEH2tm0tLTzXhExB8BU8Ghf1Wr1uTaXmB8xDQ8PY2GaEsUSAKaCT0hImJiYuOxDvtHR0ezsbGoT23IApoL39PTUaDQHBwdWO2b98eOHUqlE+2YhAFPBy2QyNscOXJ4TT01NqVQqc0nDw8Njc3PTaDRSgvf29tZqtSxPi7kEQJ1KFRUVndzPu3nzZnt7+5/1/hKi2fz8/NU6qTelhYWF0tJSGLfpXjy5diAWizs7O6/iVYOTpNfry8vLYSoUDMRfbs82LxYAIYPBABhSqfTFixecvxzM2+GzuLjI08tCqFJtF55sAGwA+A6AbD7ylMA8WnbRn2jKz+v3YP4/AQYAfdmTgIW+0AIAAAAASUVORK5CYII=</glyph>
+    </modelIdentification>
+    <objects>
+        <objectClass>
+            <name>HLAobjectRoot</name>
+            <objectClass notes="RPRnoteBase1">
+                <name>BaseEntity</name>
+                <sharing>Subscribe</sharing>
+                <semantics>A base class of aggregate and discrete scenario domain participants. The BaseEntity class is characterized by being located at a particular location in space and independently movable, if capable of movement at all. It specifically excludes elements normally considered to be a component of another element. The BaseEntity class is intended to be a container for common attributes for entities of this type. Since it lacks sufficient class specific attributes that are required for simulation purposes, federates cannot publish objects of this class. Certain simulation management federates, e.g. viewers, may subscribe to this class. Simulation federates will normally subscribe to one of the subclasses, to gain the extra information required to properly simulate the entity.</semantics>
+                <attribute notes="RPRnoteBase2">
+                    <name>EntityType</name>
+                    <dataType>EntityTypeStruct</dataType>
+                    <updateType>Static</updateType>
+                    <updateCondition>NA</updateCondition>
+                    <ownership>DivestAcquire</ownership>
+                    <sharing>PublishSubscribe</sharing>
+                    <transportation>HLAbestEffort</transportation>
+                    <order>Receive</order>
+                    <semantics>The category of the entity.</semantics>
+                </attribute>
+                <attribute notes="RPRnoteBase2">
+                    <name>EntityIdentifier</name>
+                    <dataType>EntityIdentifierStruct</dataType>
+                    <updateType>Static</updateType>
+                    <updateCondition>NA</updateCondition>
+                    <ownership>DivestAcquire</ownership>
+                    <sharing>PublishSubscribe</sharing>
+                    <transportation>HLAbestEffort</transportation>
+                    <order>Receive</order>
+                    <semantics>The unique identifier for the entity instance.</semantics>
+                </attribute>
+                <attribute notes="RPRnoteBase3">
+                    <name>IsPartOf</name>
+                    <dataType>IsPartOfStruct</dataType>
+                    <updateType>Conditional</updateType>
+                    <updateCondition>On change</updateCondition>
+                    <ownership>DivestAcquire</ownership>
+                    <sharing>PublishSubscribe</sharing>
+                    <transportation>HLAbestEffort</transportation>
+                    <order>Receive</order>
+                    <semantics>Defines if the entity if a constituent part of another entity (denoted the host entity). If the entity is a constituent part of another entity then the HostEntityIdentifier shall be set to the EntityIdentifier of the host entity and the HostRTIObjectIdentifier shall be set to the RTI object instance ID of the host entity. If the entity is not a constituent part of another entity then the HostEntityIdentifier shall be set to 0.0.0 and the HostRTIObjectIdentifier shall be set to the empty string.</semantics>
+                </attribute>
+                <attribute notes="RPRnoteBase2 RPRnoteBase18">
+                    <name>Spatial</name>
+                    <dataType>SpatialVariantStruct</dataType>
+                    <updateType>Conditional</updateType>
+                    <updateCondition notes="RPRnoteBase10 RPRnoteBase11 RPRnoteBase12 RPRnoteBase13 RPRnoteBase14">On change</updateCondition>
+                    <ownership>DivestAcquire</ownership>
+                    <sharing>PublishSubscribe</sharing>
+                    <transportation>HLAbestEffort</transportation>
+                    <order>Receive</order>
+                    <semantics>Spatial state stored in one variant record attribute.</semantics>
+                </attribute>
+                <attribute notes="RPRnoteBase3 RPRnoteBase18">
+                    <name>RelativeSpatial</name>
+                    <dataType>SpatialVariantStruct</dataType>
+                    <updateType>Conditional</updateType>
+                    <updateCondition notes="RPRnoteBase10 RPRnoteBase11 RPRnoteBase12 RPRnoteBase13 RPRnoteBase14">On change</updateCondition>
+                    <ownership>DivestAcquire</ownership>
+                    <sharing>PublishSubscribe</sharing>
+                    <transportation>HLAbestEffort</transportation>
+                    <order>Receive</order>
+                    <semantics>Relative spatial state stored in one variant record attribute.</semantics>
+                </attribute>
+            </objectClass>
+            <objectClass>
+                <name>EmbeddedSystem</name>
+                <sharing>Neither</sharing>
+                <semantics>A base class used to associate components such as sensor and emitting systems with their parent entity object.</semantics>
+                <attribute notes="RPRnoteBase2">
+                    <name>EntityIdentifier</name>
+                    <dataType>EntityIdentifierStruct</dataType>
+                    <updateType>Static</updateType>
+                    <updateCondition>NA</updateCondition>
+                    <ownership>DivestAcquire</ownership>
+                    <sharing>PublishSubscribe</sharing>
+                    <transportation>HLAbestEffort</transportation>
+                    <order>Receive</order>
+                    <semantics>The EntityIdentifier of the object which this embedded system is a part of.</semantics>
+                </attribute>
+                <attribute notes="RPRnoteBase2 RPRnoteBase4">
+                    <name>HostObjectIdentifier</name>
+                    <dataType>RTIobjectId</dataType>
+                    <updateType>Static</updateType>
+                    <updateCondition>NA</updateCondition>
+                    <ownership>DivestAcquire</ownership>
+                    <sharing>PublishSubscribe</sharing>
+                    <transportation>HLAbestEffort</transportation>
+                    <order>Receive</order>
+                    <semantics>The RTI object instance ID of the object of which this embedded system is part of.</semantics>
+                </attribute>
+                <attribute notes="RPRnoteBase2">
+                    <name>RelativePosition</name>
+                    <dataType>RelativePositionStruct</dataType>
+                    <updateType>Conditional</updateType>
+                    <updateCondition>On change</updateCondition>
+                    <ownership>DivestAcquire</ownership>
+                    <sharing>PublishSubscribe</sharing>
+                    <transportation>HLAbestEffort</transportation>
+                    <order>Receive</order>
+                    <semantics>The position of the embedded system, relative to the host object's position.</semantics>
+                </attribute>
+            </objectClass>
+        </objectClass>
+    </objects>
+    <tags>
+        <updateReflectTag>
+            <dataType>RPRUserDefinedTag</dataType>
+            <semantics>User-supplied tag provided with each update/reflect of object instance attribute values. Contains at least the DIS timestamp in the first 8 characters.</semantics>
+        </updateReflectTag>
+        <sendReceiveTag>
+            <dataType>RPRUserDefinedTag</dataType>
+            <semantics>User-supplied tag provided with each send/receive of an interaction. Contains at least the DIS timestamp in the first 8 characters.</semantics>
+        </sendReceiveTag>
+        <deleteRemoveTag>
+            <dataType>NA</dataType>
+            <semantics>NA</semantics>
+        </deleteRemoveTag>
+        <divestitureRequestTag>
+            <dataType>NA</dataType>
+            <semantics>NA</semantics>
+        </divestitureRequestTag>
+        <divestitureCompletionTag>
+            <dataType>NA</dataType>
+            <semantics>NA</semantics>
+        </divestitureCompletionTag>
+        <acquisitionRequestTag>
+            <dataType>NA</dataType>
+            <semantics>NA</semantics>
+        </acquisitionRequestTag>
+        <requestUpdateTag>
+            <dataType>NA</dataType>
+            <semantics>NA</semantics>
+        </requestUpdateTag>
+    </tags>
+    <dataTypes>
+        <simpleDataTypes>
+            <simpleData>
+                <name>AccelerationMeterPerSecondSquaredFloat32</name>
+                <representation>HLAfloat32BE</representation>
+                <units>meter per second squared (m/(s^2))</units>
+                <resolution>NA</resolution>
+                <accuracy>NA</accuracy>
+                <semantics>Linear acceleration vector composed of SI base units. Based on the Linear Acceleration Vector record as specified in IEEE 1278.1-1995 section 5.2.33b.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>AngleDegreeFloat32</name>
+                <representation>HLAfloat32BE</representation>
+                <units>degree (deg)</units>
+                <resolution>NA</resolution>
+                <accuracy>NA</accuracy>
+                <semantics>Angle, based on unit degree (of arc), unit symbol °.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>AngleRadianFloat32</name>
+                <representation>HLAfloat32BE</representation>
+                <units>radian (rad)</units>
+                <resolution>NA</resolution>
+                <accuracy>NA</accuracy>
+                <semantics>Angle, based on SI derived unit radian, unit symbol rad.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>AngularVelocityRadianPerSecondFloat32</name>
+                <representation>HLAfloat32BE</representation>
+                <units>radian per second (rad/s)</units>
+                <resolution>NA</resolution>
+                <accuracy>perfect</accuracy>
+                <semantics>Angular velocity vector composed of SI base units. Based on the Angular Velocity Vector record as specified in IEEE 1278.1-1995 section 5.2.2.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>ClockTimeHourInteger32</name>
+                <representation>HLAinteger32BE</representation>
+                <units>hour</units>
+                <resolution>1</resolution>
+                <accuracy>perfect</accuracy>
+                <semantics>Time past on the clock in full hours since a specified point in time.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>DepthMeterFloat32</name>
+                <representation>HLAfloat32BE</representation>
+                <units>meter (m)</units>
+                <resolution>NA</resolution>
+                <accuracy>NA</accuracy>
+                <semantics>Depth, based on SI base unit meter, unit symbol m.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>Float32</name>
+                <representation>HLAfloat32BE</representation>
+                <units>NA</units>
+                <resolution>NA</resolution>
+                <accuracy>NA</accuracy>
+                <semantics>Single-precision floating point number.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>Float64</name>
+                <representation>HLAfloat64BE</representation>
+                <units>NA</units>
+                <resolution>NA</resolution>
+                <accuracy>NA</accuracy>
+                <semantics>Double-precision floating point number.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>FrequencyHertzFloat32</name>
+                <representation>HLAfloat32BE</representation>
+                <units>hertz (Hz)</units>
+                <resolution>NA</resolution>
+                <accuracy>NA</accuracy>
+                <semantics>Frequency, based on SI derived unit hertz, unit symbol Hz.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>Integer16</name>
+                <representation>HLAinteger16BE</representation>
+                <units>NA</units>
+                <resolution>1</resolution>
+                <accuracy>perfect</accuracy>
+                <semantics>Integer in the range [-2^15, 2^15-1].</semantics>
+            </simpleData>
+            <simpleData>
+                <name>Integer32</name>
+                <representation>HLAinteger32BE</representation>
+                <units>NA</units>
+                <resolution>1</resolution>
+                <accuracy>perfect</accuracy>
+                <semantics>Integer in the range [-2^31, 2^31-1].</semantics>
+            </simpleData>
+            <simpleData>
+                <name>InterrogationsPerSecondFloat32</name>
+                <representation>HLAfloat32BE</representation>
+                <units>interrogations/second</units>
+                <resolution>NA</resolution>
+                <accuracy>perfect</accuracy>
+                <semantics>Number of interrogations per second.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>LengthMeterFloat32</name>
+                <representation>HLAfloat32BE</representation>
+                <units>meter (m)</units>
+                <resolution>NA</resolution>
+                <accuracy>NA</accuracy>
+                <semantics>Length, based on SI base unit meter, unit symbol m.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>MassKilogramFloat32</name>
+                <representation>HLAfloat32BE</representation>
+                <units>kilogram (kg)</units>
+                <resolution>NA</resolution>
+                <accuracy>NA</accuracy>
+                <semantics>Mass, based on SI base unit kilogram, unit symbol kg.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>MeterFloat32</name>
+                <representation>HLAfloat32BE</representation>
+                <units>meter (m)</units>
+                <resolution>NA</resolution>
+                <accuracy>perfect</accuracy>
+                <semantics>Datatype based on SI base unit meter, unit symbol m.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>MeterFloat64</name>
+                <representation>HLAfloat64BE</representation>
+                <units>meter (m)</units>
+                <resolution>NA</resolution>
+                <accuracy>perfect</accuracy>
+                <semantics>Datatype based on SI base unit meter, unit symbol m.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>Octet</name>
+                <representation>HLAoctet</representation>
+                <units>NA</units>
+                <resolution>1</resolution>
+                <accuracy>perfect</accuracy>
+                <semantics>Uninterpreted 8-bit value.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>PercentFloat32</name>
+                <representation>HLAfloat32BE</representation>
+                <units>percent (%)</units>
+                <resolution>NA</resolution>
+                <accuracy>NA</accuracy>
+                <semantics>Percentage</semantics>
+            </simpleData>
+            <simpleData>
+                <name>PercentUnsignedInteger32</name>
+                <representation>RPRunsignedInteger32BE</representation>
+                <units>percent (%)</units>
+                <resolution>1</resolution>
+                <accuracy>perfect</accuracy>
+                <semantics>Percentage</semantics>
+            </simpleData>
+            <simpleData>
+                <name>PowerRatioDecibelMilliwattFloat32</name>
+                <representation>HLAfloat32BE</representation>
+                <units>decibel milliwatt (dBm)</units>
+                <resolution>NA</resolution>
+                <accuracy>perfect</accuracy>
+                <semantics>Power ratio in decibels (dB) of a measured power referenced to 1 milliwatt (mW).</semantics>
+            </simpleData>
+            <simpleData>
+                <name>RevolutionsPerMinuteInteger16</name>
+                <representation>HLAinteger16BE</representation>
+                <units>revolutions per minute (RPM)</units>
+                <resolution>1</resolution>
+                <accuracy>NA</accuracy>
+                <semantics>Frequency of rotation, expressed in revolutions per minute.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>TemperatureDegreeCelsiusFloat32</name>
+                <representation>HLAfloat32BE</representation>
+                <units>degree Celsius (C)</units>
+                <resolution>NA</resolution>
+                <accuracy>NA</accuracy>
+                <semantics>Temperature, based on SI derived unit degree Celsius, unit symbol °C.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>TimeMicrosecondFloat32</name>
+                <representation>HLAfloat32BE</representation>
+                <units>microsecond</units>
+                <resolution>NA</resolution>
+                <accuracy>NA</accuracy>
+                <semantics>Time, based on SI base unit second, expressed in microsecond, unit symbol μs.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>TimeMillisecondUnsignedInteger32</name>
+                <representation>RPRunsignedInteger32BE</representation>
+                <units>millisecond (ms)</units>
+                <resolution>NA</resolution>
+                <accuracy>NA</accuracy>
+                <semantics>Time, based on SI base unit second, expressed in millisecond, unit symbol ms.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>TimeSecondInteger32</name>
+                <representation>HLAinteger32BE</representation>
+                <units>second (s)</units>
+                <resolution>1</resolution>
+                <accuracy>perfect</accuracy>
+                <semantics>Time, based on SI base unit second, unit symbol s.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>TimestampUnsignedInteger32</name>
+                <representation>RPRunsignedInteger32BE</representation>
+                <units>3600/(2^31) second</units>
+                <resolution>1</resolution>
+                <accuracy>perfect</accuracy>
+                <semantics>The time past the hour, scaled so that value 0 represents the start of the hour and value 2^31 - 1 represents one time unit before the start of the next hour, thereby resulting in each time unit representing exactly 3600/(2^31) s, which is approximately 1.67638063 microsecond.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>UnsignedInteger16</name>
+                <representation>RPRunsignedInteger16BE</representation>
+                <units>NA</units>
+                <resolution>1</resolution>
+                <accuracy>perfect</accuracy>
+                <semantics>Integer in the range [0, 2^16-1].</semantics>
+            </simpleData>
+            <simpleData>
+                <name>UnsignedInteger32</name>
+                <representation>RPRunsignedInteger32BE</representation>
+                <units>NA</units>
+                <resolution>1</resolution>
+                <accuracy>perfect</accuracy>
+                <semantics>Integer in the range [0, 2^32-1].</semantics>
+            </simpleData>
+            <simpleData>
+                <name>UnsignedInteger64</name>
+                <representation>RPRunsignedInteger64BE</representation>
+                <units>NA</units>
+                <resolution>1</resolution>
+                <accuracy>perfect</accuracy>
+                <semantics>Integer in the range [0, 2^64-1].</semantics>
+            </simpleData>
+            <simpleData>
+                <name>UnsignedInteger8</name>
+                <representation>RPRunsignedInteger8BE</representation>
+                <units>NA</units>
+                <resolution>1</resolution>
+                <accuracy>perfect</accuracy>
+                <semantics>Integer in the range [0, 2^8-1].</semantics>
+            </simpleData>
+            <simpleData>
+                <name>VelocityMeterPerSecondFloat32</name>
+                <representation>HLAfloat32BE</representation>
+                <units>meter per second (m/s)</units>
+                <resolution>NA</resolution>
+                <accuracy>perfect</accuracy>
+                <semantics>Speed/Velocity in meter per second.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>WavelengthMicronFloat32</name>
+                <representation>HLAfloat32BE</representation>
+                <units>micron</units>
+                <resolution>NA</resolution>
+                <accuracy>perfect</accuracy>
+                <semantics>Wavelength expressed in micrometer.</semantics>
+            </simpleData>
+        </simpleDataTypes>
+        <arrayDataTypes>
+            <arrayData>
+                <name>RPRUserDefinedTag</name>
+                <dataType>HLAASCIIchar</dataType>
+                <cardinality>[8..2147483647]</cardinality>
+                <encoding>RPRnullTerminatedArray</encoding>
+                <semantics>The array shall be at least 8 bytes (octets) in size, which shall contain the time according to the DIS time stamp field format (IEEE 1278.1-1995 section 5.2.31) converted into hexadecimal American Standard Code for Information Interchange (ASCII) character representation (0-9 and A-F), with leading zeros included.  The ordering of the characters shall be in accordance with section 5.1.1 of IEEE 1278.1-1995, that is most significant octet first, with the most significant bits first (i.e. the character for bits 4-7 precedes the character for bits 0-3). This encoding is equivalent to the result of the 'C'-statement "sprintf(UserTag, "%08X", DIStimestamp)," where 'DIStimestamp' is represented in native format.
+
+More user-supplied information may be included, starting from the 9th character, as specified in the federation agreements.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>ArticulatedParameterStructLengthlessArray</name>
+                <dataType>ArticulatedParameterStruct</dataType>
+                <cardinality>Dynamic</cardinality>
+                <encoding>RPRlengthlessArray</encoding>
+                <semantics>Dynamic array of ArticulatedParameterStruct elements, may also contain no elements. The array is encoded without array length, containing only the elements.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>ClockTimeStructLengthlessArray</name>
+                <dataType>ClockTimeStruct</dataType>
+                <cardinality>Dynamic</cardinality>
+                <encoding>RPRlengthlessArray</encoding>
+                <semantics>Dynamic array of ClockTimeStruct elements, may also contain no elements. The array is encoded without array length, containing only the elements.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>EntityTypeStructLengthlessArray</name>
+                <dataType>EntityTypeStruct</dataType>
+                <cardinality>Dynamic</cardinality>
+                <encoding>RPRlengthlessArray</encoding>
+                <semantics>Dynamic array of EntityTypeStruct elements, may also contain no elements. The array is encoded without array length, containing only the elements.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>Float32Array1Plus</name>
+                <dataType>Float32</dataType>
+                <cardinality>[1..2147483647]</cardinality>
+                <encoding>HLAvariableArray</encoding>
+                <semantics>Generic dynamic array of Float32 elements, containing at least one element.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>Integer16Array1Plus</name>
+                <dataType>Integer16</dataType>
+                <cardinality>[1..2147483647]</cardinality>
+                <encoding>HLAvariableArray</encoding>
+                <semantics>Generic dynamic array of Integer16 elements, containing at least one element.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>OctetArray</name>
+                <dataType>Octet</dataType>
+                <cardinality>Dynamic</cardinality>
+                <encoding>HLAvariableArray</encoding>
+                <semantics>Generic dynamic array of Octet elements, may also contain no elements.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>OctetArray1Plus</name>
+                <dataType>Octet</dataType>
+                <cardinality>[1..2147483647]</cardinality>
+                <encoding>HLAvariableArray</encoding>
+                <semantics>Generic dynamic array of Octet elements, containing at least one element.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>OctetArray2</name>
+                <dataType>Octet</dataType>
+                <cardinality>2</cardinality>
+                <encoding>HLAfixedArray</encoding>
+                <semantics>Generic array of two Octet elements.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>OctetArray3</name>
+                <dataType>Octet</dataType>
+                <cardinality>3</cardinality>
+                <encoding>HLAfixedArray</encoding>
+                <semantics>Generic array of three Octet elements.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>OctetArray4</name>
+                <dataType>Octet</dataType>
+                <cardinality>4</cardinality>
+                <encoding>HLAfixedArray</encoding>
+                <semantics>Generic array of four Octet elements.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>OctetArray7</name>
+                <dataType>Octet</dataType>
+                <cardinality>7</cardinality>
+                <encoding>HLAfixedArray</encoding>
+                <semantics>Generic array of seven Octet elements.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>OctetArray8</name>
+                <dataType>Octet</dataType>
+                <cardinality>8</cardinality>
+                <encoding>HLAfixedArray</encoding>
+                <semantics>Generic array of eight Octet elements.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>OctetPadding32Array</name>
+                <dataType>Octet</dataType>
+                <cardinality>Dynamic</cardinality>
+                <encoding>RPRpaddingTo32Array</encoding>
+                <semantics>Generic dynamic array of meaningless Octet elements, to align the subsequent data structure to the next 32 bit octet boundary value (OBV). The array is encoded without array length, containing zero to three elements.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>OctetPadding64Array</name>
+                <dataType>Octet</dataType>
+                <cardinality>Dynamic</cardinality>
+                <encoding>RPRpaddingTo64Array</encoding>
+                <semantics>Generic dynamic array of meaningless Octet elements, to align the subsequent data structure to the next 64 bit octet boundary value (OBV). The array is encoded without array length, containing zero to seven elements.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>OrientationStructLengthlessArray</name>
+                <dataType>OrientationStruct</dataType>
+                <cardinality>Dynamic</cardinality>
+                <encoding>RPRlengthlessArray</encoding>
+                <semantics>Dynamic array of OrientationStruct elements, may also contain no elements. The array is encoded without array length, containing only the elements.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>UnsignedInteger16Array1Plus</name>
+                <dataType>UnsignedInteger16</dataType>
+                <cardinality>[1..2147483647]</cardinality>
+                <encoding>HLAvariableArray</encoding>
+                <semantics>Generic dynamic array of UnsignedInteger16 elements, containing at least one element.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>UnsignedInteger32LengthlessArray</name>
+                <dataType>UnsignedInteger32</dataType>
+                <cardinality>Dynamic</cardinality>
+                <encoding>RPRlengthlessArray</encoding>
+                <semantics>Generic dynamic array of UnsignedInteger32 elements, may also contain no elements. The array is encoded without array length, containing only the elements.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>UnsignedInteger64Array1Plus</name>
+                <dataType>UnsignedInteger64</dataType>
+                <cardinality>[1..2147483647]</cardinality>
+                <encoding>HLAvariableArray</encoding>
+                <semantics>Generic dynamic array of UnsignedInteger64 elements, containing at least one element.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>UnsignedInteger8LengthlessArray</name>
+                <dataType>UnsignedInteger8</dataType>
+                <cardinality>Dynamic</cardinality>
+                <encoding>RPRlengthlessArray</encoding>
+                <semantics>Generic dynamic array of UnsignedInteger8 elements, may also contain no elements. The array is encoded without array length, containing only the elements.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>WorldLocationStructLengthlessArray</name>
+                <dataType>WorldLocationStruct</dataType>
+                <cardinality>Dynamic</cardinality>
+                <encoding>RPRlengthlessArray</encoding>
+                <semantics>Dynamic array of WorldLocationStruct elements, may also contain no elements. The array is encoded without array length, containing only the elements.</semantics>
+            </arrayData>
+        </arrayDataTypes>
+        <fixedRecordDataTypes>
+            <fixedRecordData>
+                <name>AccelerationVectorStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>The magnitude of the change in linear velocity over time.</semantics>
+                <field>
+                    <name>XAcceleration</name>
+                    <dataType>AccelerationMeterPerSecondSquaredFloat32</dataType>
+                    <semantics>Acceleration component along the X axis.</semantics>
+                </field>
+                <field>
+                    <name>YAcceleration</name>
+                    <dataType>AccelerationMeterPerSecondSquaredFloat32</dataType>
+                    <semantics>Acceleration component along the Y axis.</semantics>
+                </field>
+                <field>
+                    <name>ZAcceleration</name>
+                    <dataType>AccelerationMeterPerSecondSquaredFloat32</dataType>
+                    <semantics>Acceleration component along the Z axis.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>AngularVelocityVectorStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>The rate at which the orientation is changing over time, in body coordinates.</semantics>
+                <field>
+                    <name>XAngularVelocity</name>
+                    <dataType>AngularVelocityRadianPerSecondFloat32</dataType>
+                    <semantics>Acceleration component about the X axis.</semantics>
+                </field>
+                <field>
+                    <name>YAngularVelocity</name>
+                    <dataType>AngularVelocityRadianPerSecondFloat32</dataType>
+                    <semantics>Acceleration component about the Y axis.</semantics>
+                </field>
+                <field>
+                    <name>ZAngularVelocity</name>
+                    <dataType>AngularVelocityRadianPerSecondFloat32</dataType>
+                    <semantics>Acceleration component about the Z axis.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>ArticulatedParameterStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Structure to specify a movable or attached part of an entity. Based on the Articulation Parameter record as specified in IEEE 1278.1-1995 section 5.2.5. 
+ 
+Note that usage of this datatype for the PhyscialEntity object class attribute ArticulatedParametersArray and MunitionDetonation interaction class parameter ArticulatedPartData shall be in accordance with IEEE 1278.1-1995 Annex A.</semantics>
+                <field>
+                    <name>ArticulatedParameterChange</name>
+                    <dataType>Octet</dataType>
+                    <semantics>Indicator of a change to the part. This field shall be set to zero for each exercise and sequentially incremented by one for each change in articulation parameters. In the case where all possible values are exhausted, the numbers shall be reused beginning at zero.</semantics>
+                </field>
+                <field>
+                    <name>PartAttachedTo</name>
+                    <dataType>UnsignedInteger16</dataType>
+                    <semantics>Identification of the articulated part to which this articulation parameter is attached. This field shall contain the value zero if the articulated part is attached directly to the entity.</semantics>
+                </field>
+                <field>
+                    <name>ParameterValue</name>
+                    <dataType>ParameterValueVariantStruct</dataType>
+                    <semantics>Details of the parameter: whether it is an articulated or an attached part, and its type and value.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData notes="RPRnoteBase7">
+                <name>ArticulatedPartsStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Structure to represent the state of a movable part of an entity.</semantics>
+                <field>
+                    <name>Class</name>
+                    <dataType>ArticulatedPartsTypeEnum32</dataType>
+                    <semantics>The type class uniquely identifies a particular articulated part on a given entity type. Guidance for uniquely assigning type classes to an entity's articulated parts is given in section 4.8 of the enumeration document (SISO-REF-010).</semantics>
+                </field>
+                <field>
+                    <name>TypeMetric</name>
+                    <dataType>ArticulatedTypeMetricEnum32</dataType>
+                    <semantics>The type metric uniquely identifies the transformation to be applied to the articulated part.</semantics>
+                </field>
+                <field>
+                    <name>Value</name>
+                    <dataType>Float32</dataType>
+                    <semantics>Value of the transformation to be applied to the articulated part.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>AttachedPartsStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Structure to represent removable parts that may be attached to an entity.</semantics>
+                <field>
+                    <name>Station</name>
+                    <dataType>StationEnum32</dataType>
+                    <semantics>Identification of the location (or station) to which the part is attached.</semantics>
+                </field>
+                <field>
+                    <name>StoreType</name>
+                    <dataType>EntityTypeStruct</dataType>
+                    <semantics>The entity type of the attached part.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>ClockTimeStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Specification of the point in time of an occurrence. Based on the Clock Time record as specified in IEEE 1278.1-1995 section 5.2.8.</semantics>
+                <field>
+                    <name>Hours</name>
+                    <dataType>ClockTimeHourInteger32</dataType>
+                    <semantics>The number of hours since 0000 hours, January 1, 1970 UTC.</semantics>
+                </field>
+                <field>
+                    <name>TimePastTheHour</name>
+                    <dataType>TimestampUnsignedInteger32</dataType>
+                    <semantics>The time past the hour indicated in the Hours field.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>ConstituentPartRelationshipStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>The relationship of the constituent part object to its host object. Based on the Relationship record as specified in IEEE 1278.1a-1998 section 5.2.56.</semantics>
+                <field>
+                    <name>Nature</name>
+                    <dataType>ConstituentPartNatureEnum16</dataType>
+                    <semantics>The nature or purpose for the joining of the constituent part object to the host object.</semantics>
+                </field>
+                <field>
+                    <name>Position</name>
+                    <dataType>ConstituentPartPositionEnum16</dataType>
+                    <semantics>The position of the constituent part object with respect to the host object.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>DimensionStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Bounding box in X,Y,Z axis.</semantics>
+                <field>
+                    <name>XAxisLength</name>
+                    <dataType>MeterFloat32</dataType>
+                    <semantics>Length in meters along X axis.</semantics>
+                </field>
+                <field>
+                    <name>YAxisLength</name>
+                    <dataType>MeterFloat32</dataType>
+                    <semantics>Length in meters along Y axis.</semantics>
+                </field>
+                <field>
+                    <name>ZAxisLength</name>
+                    <dataType>MeterFloat32</dataType>
+                    <semantics>Length in meters along Z axis.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>EntityIdentifierStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Unique, exercise-wide identification of the entity, or a symbolic group address referencing multiple entities or a simulation application. Based on the Entity Identifier record as specified in IEEE 1278.1-1995 section 5.2.14.</semantics>
+                <field>
+                    <name>FederateIdentifier</name>
+                    <dataType>FederateIdentifierStruct</dataType>
+                    <semantics>Simulation application (federate) identifier.</semantics>
+                </field>
+                <field>
+                    <name>EntityNumber</name>
+                    <dataType>UnsignedInteger16</dataType>
+                    <semantics>Each entity in a given simulation application shall be given an entity identifier number unique to all other entities in that application. This identifier number is valid for the duration of the exercise; however, entity identifier numbers may be reused when all possible numbers have been exhausted. No entity shall have an entity identifier number of NO_ENTITY (0), ALL_ENTITIES (0xFFFF), or RQST_ASSIGN_ID (0xFFFE). The entity identifier number need not be registered or retained for future exercises. An entity identifier number equal to zero with valid site and application identification shall address a simulation application. An entity identifier number equal to ALL_ENTITIES shall mean all entities within the specified site and application. An entity identifier number equal to RQST_ASSIGN_ID allows the receiver of the CreateEntity interaction to define the entity identifier number of the new entity. The new entity will specify its entity identifier number in the Acknowledge interaction.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData notes="RPRnoteBase5">
+                <name>EntityTypeStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Type of entity. Based on the Entity Type record as specified in IEEE 1278.1-1995 section 5.2.16.</semantics>
+                <field>
+                    <name>EntityKind</name>
+                    <dataType>Octet</dataType>
+                    <semantics>Kind of entity.</semantics>
+                </field>
+                <field>
+                    <name>Domain</name>
+                    <dataType>Octet</dataType>
+                    <semantics>Domain in which the entity operates.</semantics>
+                </field>
+                <field>
+                    <name>CountryCode</name>
+                    <dataType>UnsignedInteger16</dataType>
+                    <semantics>Country to which the design of the entity is attributed.</semantics>
+                </field>
+                <field>
+                    <name>Category</name>
+                    <dataType>Octet</dataType>
+                    <semantics>Main category that describes the entity.</semantics>
+                </field>
+                <field>
+                    <name>Subcategory</name>
+                    <dataType>Octet</dataType>
+                    <semantics>Subcategory to which an entity belongs based on the Category field.</semantics>
+                </field>
+                <field>
+                    <name>Specific</name>
+                    <dataType>Octet</dataType>
+                    <semantics>Specific information about an entity based on the Subcategory field.</semantics>
+                </field>
+                <field>
+                    <name>Extra</name>
+                    <dataType>Octet</dataType>
+                    <semantics>Extra information required to describe a particular entity.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>EventIdentifierStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Identification of an event. Based on the Event Identifier record as specified in IEEE 1278.1-1995 section 5.2.18.</semantics>
+                <field>
+                    <name>EventCount</name>
+                    <dataType>UnsignedInteger16</dataType>
+                    <semantics>The event number. Uniquely assigned by the simulation application (federate) that initiates the sequence of events. It shall be set to one for each exercise and incremented by one for each event. In the case where all possible values are exhausted, the numbers may be reused beginning again at one.</semantics>
+                </field>
+                <field>
+                    <name>IssuingObjectIdentifier</name>
+                    <dataType>RTIobjectId</dataType>
+                    <semantics>Identification of the object issuing the event.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>FederateIdentifierStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Unique identification of the simulation application (federate) in an exercise, or a symbolic group address referencing multiple simulation applications. Based on the Simulation Address record as specified in IEEE 1278.1-1995 section 5.2.14.1.</semantics>
+                <field>
+                    <name>SiteID</name>
+                    <dataType>UnsignedInteger16</dataType>
+                    <semantics>Each site shall be assigned a unique site identification. No individual site shall be assigned an identification number containing NO_SITE (0) or ALL_SITES (0xFFFF). An identification number equal to ALL_SITES (0xFFFF) shall mean all sites; this may be used to initialize or start all sites. The mechanism by which Site Identification numbers are assigned is part of federation agreements.</semantics>
+                </field>
+                <field>
+                    <name>ApplicationID</name>
+                    <dataType>UnsignedInteger16</dataType>
+                    <semantics>Each simulation application (federate) at a site shall be assigned an identification number unique within that site. No simulation application shall be assigned an identification number containing NO_APPLIC (0) or ALL_APPLIC (0xFFFF). An application identification number equal to ALL_APPLIC (0xFFFF) shall mean all applications; this may be used to start all applications within a site. One or more simulation applications may reside in a single host computer. The mechanism by which application identification numbers are assigned is part of federation agreements.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>IsPartOfStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Defines the spatial relationship between two objects.</semantics>
+                <field>
+                    <name>HostEntityIdentifier</name>
+                    <dataType>EntityIdentifierStruct</dataType>
+                    <semantics>The identifier of the entity of which the object is a constituent part.</semantics>
+                </field>
+                <field>
+                    <name>HostRTIObjectIdentifier</name>
+                    <dataType>RTIobjectId</dataType>
+                    <semantics>The RTI instance identifier of the object of which this object is a constituent part.</semantics>
+                </field>
+                <field>
+                    <name>Relationship</name>
+                    <dataType>ConstituentPartRelationshipStruct</dataType>
+                    <semantics>The relationship of the constituent part object to its host object.</semantics>
+                </field>
+                <field>
+                    <name>NamedLocation</name>
+                    <dataType>NamedLocationStruct</dataType>
+                    <semantics>The discrete positional relationship of the constituent part object with respect to its host object.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData notes="RPRnoteBase20">
+                <name>LinearSegmentStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Specifies linear object segment characteristics.</semantics>
+                <field>
+                    <name>SegmentNumber</name>
+                    <dataType>UnsignedInteger32</dataType>
+                    <semantics>Identifies the individual segment.</semantics>
+                </field>
+                <field>
+                    <name>PercentComplete</name>
+                    <dataType>PercentUnsignedInteger32</dataType>
+                    <semantics>Specifies the percent completion of the segment.</semantics>
+                </field>
+                <field>
+                    <name>Location</name>
+                    <dataType>WorldLocationStruct</dataType>
+                    <semantics>Specifies the location of the segment.</semantics>
+                </field>
+                <field>
+                    <name>Orientation</name>
+                    <dataType>OrientationStruct</dataType>
+                    <semantics>Specifies the orientation of the segment.</semantics>
+                </field>
+                <field>
+                    <name>Length</name>
+                    <dataType>UnsignedInteger16</dataType>
+                    <semantics>Specifies the length of the segment, in meters, extending in the positive X direction.</semantics>
+                </field>
+                <field>
+                    <name>Width</name>
+                    <dataType>UnsignedInteger16</dataType>
+                    <semantics>Specifies the total width of the segment, in meters; one-half of the width shall extend in the positive Y direction, and one-half of the width shall extend in the negative Y direction.</semantics>
+                </field>
+                <field>
+                    <name>Height</name>
+                    <dataType>UnsignedInteger16</dataType>
+                    <semantics>Specifies the height of the segment, in meters, above ground.</semantics>
+                </field>
+                <field>
+                    <name>Depth</name>
+                    <dataType>UnsignedInteger16</dataType>
+                    <semantics>Specifies the depth of the segment, in meters, below ground level.</semantics>
+                </field>
+                <field>
+                    <name>DamagedState</name>
+                    <dataType>DamageStatusEnum32</dataType>
+                    <semantics>Specifies the damaged appearance of the segment.</semantics>
+                </field>
+                <field>
+                    <name>Deactivated</name>
+                    <dataType>RPRboolean</dataType>
+                    <semantics>Specifies whether or not the segment has been deactivated (it has ceased to exist in the synthetic environment).</semantics>
+                </field>
+                <field>
+                    <name>Flaming</name>
+                    <dataType>RPRboolean</dataType>
+                    <semantics>Specifies whether or not the segment is aflame.</semantics>
+                </field>
+                <field>
+                    <name>ObjectPreDistributed</name>
+                    <dataType>RPRboolean</dataType>
+                    <semantics>Specifies whether or not the segment was created before the start of the exercise.</semantics>
+                </field>
+                <field>
+                    <name>Smoking</name>
+                    <dataType>RPRboolean</dataType>
+                    <semantics>Specifies whether or not the segment is smoking (creating a smoke plume).</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>NamedLocationStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>The discrete positional relationship of the constituent part object with respect to its host object. Based on the specifications in IEEE 1278.1a-1998 of the IsPartOf PDU 'Location of Part' (paragraph 5.3.9.4e) and 'Named Location' (paragraph 5.3.9.4f) fields.</semantics>
+                <field>
+                    <name>StationNumber</name>
+                    <dataType>Integer16</dataType>
+                    <semantics>The number of the particular station at which the constituent part is attached.</semantics>
+                </field>
+                <field>
+                    <name>StationName</name>
+                    <dataType>StationNameLocationVariantStruct</dataType>
+                    <semantics>The name of the station where the constituent part is located.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>OrientationStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>The orientation of an object in the world coordinate system, as specified in IEEE Std 1278.1-1995 section 1.3.2.</semantics>
+                <field>
+                    <name>Psi</name>
+                    <dataType>AngleRadianFloat32</dataType>
+                    <semantics>Rotation about the Z axis.</semantics>
+                </field>
+                <field>
+                    <name>Theta</name>
+                    <dataType>AngleRadianFloat32</dataType>
+                    <semantics>Rotation about the Y axis.</semantics>
+                </field>
+                <field>
+                    <name>Phi</name>
+                    <dataType>AngleRadianFloat32</dataType>
+                    <semantics>Rotation about the X axis.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>RelativePositionStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Relative position in right-handed Cartesian coordinates.</semantics>
+                <field>
+                    <name>BodyXDistance</name>
+                    <dataType>MeterFloat32</dataType>
+                    <semantics>The distance from the reference location along the X axis.</semantics>
+                </field>
+                <field>
+                    <name>BodyYDistance</name>
+                    <dataType>MeterFloat32</dataType>
+                    <semantics>The distance from the reference location along the Y axis.</semantics>
+                </field>
+                <field>
+                    <name>BodyZDistance</name>
+                    <dataType>MeterFloat32</dataType>
+                    <semantics>The distance from the reference location along the Z axis.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>RelativeRangeBearingStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Relative position in polar coordinates.</semantics>
+                <field>
+                    <name>Range</name>
+                    <dataType>LengthMeterFloat32</dataType>
+                    <semantics>The range from the reference location.</semantics>
+                </field>
+                <field>
+                    <name>Bearing</name>
+                    <dataType>AngleRadianFloat32</dataType>
+                    <semantics>The bearing from the reference location.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData notes="RPRnoteBase15">
+                <name>SpatialFPStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Spatial structure for Dead Reckoning Algorithm FPW (2) and FPB (6).</semantics>
+                <field>
+                    <name>WorldLocation</name>
+                    <dataType>WorldLocationStruct</dataType>
+                    <semantics>Location of the object.</semantics>
+                </field>
+                <field notes="RPRnoteBase19">
+                    <name>IsFrozen</name>
+                    <dataType>RPRboolean</dataType>
+                    <semantics>Whether the object is frozen or not.</semantics>
+                </field>
+                <field>
+                    <name>Orientation</name>
+                    <dataType>OrientationStruct</dataType>
+                    <semantics>The angles of rotation around the coordinate axes between the object's attitude and the reference coordinate system axes (calculated as the Tait-Bryan Euler angles specifying the successive rotations needed to transform from the world coordinate system to the entity coordinate system).</semantics>
+                </field>
+                <field>
+                    <name>VelocityVector</name>
+                    <dataType>VelocityVectorStruct</dataType>
+                    <semantics>The rate at which an object's position is changing over time.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData notes="RPRnoteBase15">
+                <name>SpatialFVStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Spatial structure for Dead Reckoning Algorithm FVW (5) and RVB (9).</semantics>
+                <field>
+                    <name>WorldLocation</name>
+                    <dataType>WorldLocationStruct</dataType>
+                    <semantics>Location of the object.</semantics>
+                </field>
+                <field notes="RPRnoteBase19">
+                    <name>IsFrozen</name>
+                    <dataType>RPRboolean</dataType>
+                    <semantics>Whether the object is frozen or not.</semantics>
+                </field>
+                <field>
+                    <name>Orientation</name>
+                    <dataType>OrientationStruct</dataType>
+                    <semantics>The angles of rotation around the coordinate axes between the object's attitude and the reference coordinate system axes (calculated as the Tait-Bryan Euler angles specifying the successive rotations needed to transform from the world coordinate system to the entity coordinate system).</semantics>
+                </field>
+                <field>
+                    <name>VelocityVector</name>
+                    <dataType>VelocityVectorStruct</dataType>
+                    <semantics>The rate at which an object's position is changing over time.</semantics>
+                </field>
+                <field>
+                    <name>AccelerationVector</name>
+                    <dataType>AccelerationVectorStruct</dataType>
+                    <semantics>The magnitude of the change in linear velocity of an object over time.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData notes="RPRnoteBase15">
+                <name>SpatialRPStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Spatial structure for Dead Reckoning Algorithm RPW (3) and RPB (7).</semantics>
+                <field>
+                    <name>WorldLocation</name>
+                    <dataType>WorldLocationStruct</dataType>
+                    <semantics>Location of the object.</semantics>
+                </field>
+                <field notes="RPRnoteBase19">
+                    <name>IsFrozen</name>
+                    <dataType>RPRboolean</dataType>
+                    <semantics>Whether the object is frozen or not.</semantics>
+                </field>
+                <field>
+                    <name>Orientation</name>
+                    <dataType>OrientationStruct</dataType>
+                    <semantics>The angles of rotation around the coordinate axes between the object's attitude and the reference coordinate system axes (calculated as the Tait-Bryan Euler angles specifying the successive rotations needed to transform from the world coordinate system to the entity coordinate system).</semantics>
+                </field>
+                <field>
+                    <name>VelocityVector</name>
+                    <dataType>VelocityVectorStruct</dataType>
+                    <semantics>The rate at which an object's position is changing over time.</semantics>
+                </field>
+                <field>
+                    <name>AngularVelocity</name>
+                    <dataType>AngularVelocityVectorStruct</dataType>
+                    <semantics>The rate at which an object's orientation is changing over time.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData notes="RPRnoteBase15">
+                <name>SpatialRVStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Spatial structure for Dead Reckoning Algorithm RVW (4) and RVB (8).</semantics>
+                <field>
+                    <name>WorldLocation</name>
+                    <dataType>WorldLocationStruct</dataType>
+                    <semantics>Location of the object.</semantics>
+                </field>
+                <field notes="RPRnoteBase19">
+                    <name>IsFrozen</name>
+                    <dataType>RPRboolean</dataType>
+                    <semantics>Whether the object is frozen or not.</semantics>
+                </field>
+                <field>
+                    <name>Orientation</name>
+                    <dataType>OrientationStruct</dataType>
+                    <semantics>The angles of rotation around the coordinate axes between the object's attitude and the reference coordinate system axes (calculated as the Tait-Bryan Euler angles specifying the successive rotations needed to transform from the world coordinate system to the entity coordinate system).</semantics>
+                </field>
+                <field>
+                    <name>VelocityVector</name>
+                    <dataType>VelocityVectorStruct</dataType>
+                    <semantics>The rate at which an object's position is changing over time.</semantics>
+                </field>
+                <field>
+                    <name>AccelerationVector</name>
+                    <dataType>AccelerationVectorStruct</dataType>
+                    <semantics>The magnitude of the change in linear velocity of an object over time.</semantics>
+                </field>
+                <field>
+                    <name>AngularVelocity</name>
+                    <dataType>AngularVelocityVectorStruct</dataType>
+                    <semantics>The rate at which an object's orientation is changing over time.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData notes="RPRnoteBase15">
+                <name>SpatialStaticStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Spatial structure for Dead Reckoning Algorithm Static (1).</semantics>
+                <field>
+                    <name>WorldLocation</name>
+                    <dataType>WorldLocationStruct</dataType>
+                    <semantics>Location of the object.</semantics>
+                </field>
+                <field notes="RPRnoteBase19">
+                    <name>IsFrozen</name>
+                    <dataType>RPRboolean</dataType>
+                    <semantics>Whether the object is frozen or not.</semantics>
+                </field>
+                <field>
+                    <name>Orientation</name>
+                    <dataType>OrientationStruct</dataType>
+                    <semantics>The angles of rotation around the coordinate axes between the object's attitude and the reference coordinate system axes (calculated as the Tait-Bryan Euler angles specifying the successive rotations needed to transform from the world coordinate system to the entity coordinate system).</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData notes="RPRnoteBase16 RPRnoteBase17">
+                <name>VariableDatumStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>These fields shall specify the types of variable datum, their length, and their value.</semantics>
+                <field>
+                    <name>DatumID</name>
+                    <dataType>DatumIdentifierEnum32</dataType>
+                    <semantics>The fixed datum id represented by a 32-bit enumeration</semantics>
+                </field>
+                <field>
+                    <name>DatumLength</name>
+                    <dataType>UnsignedInteger32</dataType>
+                    <semantics>This field shall specify the length of the variable datum in bits.</semantics>
+                </field>
+                <field>
+                    <name>DatumValue</name>
+                    <dataType>UnsignedInteger64Array1Plus</dataType>
+                    <semantics>Value of the variable datum defined by the Variable Datum ID and Variable Datum length. This field shall be padded at the end to make the length a multiple of 64-bits.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>VelocityVectorStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>The rate at which the position is changing over time.</semantics>
+                <field>
+                    <name>XVelocity</name>
+                    <dataType>VelocityMeterPerSecondFloat32</dataType>
+                    <semantics>Velocity component along the X axis.</semantics>
+                </field>
+                <field>
+                    <name>YVelocity</name>
+                    <dataType>VelocityMeterPerSecondFloat32</dataType>
+                    <semantics>Velocity component along the Y axis.</semantics>
+                </field>
+                <field>
+                    <name>ZVelocity</name>
+                    <dataType>VelocityMeterPerSecondFloat32</dataType>
+                    <semantics>Velocity component along the Z axis.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>WorldLocationStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>The location of an object in the world coordinate system, as specified in IEEE Std 1278.1-1995 section 1.3.2.</semantics>
+                <field>
+                    <name>X</name>
+                    <dataType>MeterFloat64</dataType>
+                    <semantics>Distance from the origin along the X axis.</semantics>
+                </field>
+                <field>
+                    <name>Y</name>
+                    <dataType>MeterFloat64</dataType>
+                    <semantics>Distance from the origin along the Y axis.</semantics>
+                </field>
+                <field>
+                    <name>Z</name>
+                    <dataType>MeterFloat64</dataType>
+                    <semantics>Distance from the origin along the Z axis.</semantics>
+                </field>
+            </fixedRecordData>
+        </fixedRecordDataTypes>
+        <variantRecordDataTypes>
+            <variantRecordData>
+                <name>ParameterValueVariantStruct</name>
+                <discriminant>ArticulatedParameterType</discriminant>
+                <dataType>ParameterTypeEnum32</dataType>
+                <alternative>
+                    <enumerator>ArticulatedPart</enumerator>
+                    <name>ArticulatedParts</name>
+                    <dataType>ArticulatedPartsStruct</dataType>
+                    <semantics>Alternative for an articulated part.</semantics>
+                </alternative>
+                <alternative>
+                    <enumerator>AttachedPart</enumerator>
+                    <name>AttachedParts</name>
+                    <dataType>AttachedPartsStruct</dataType>
+                    <semantics>Alternative for an attached part.</semantics>
+                </alternative>
+                <encoding>HLAvariantRecord</encoding>
+                <semantics>Variant record specifying the type of articulation parameter (articulated or attached part), and its type and value.</semantics>
+            </variantRecordData>
+            <variantRecordData>
+                <name>SpatialVariantStruct</name>
+                <discriminant>DeadReckoningAlgorithm</discriminant>
+                <dataType>DeadReckoningAlgorithmEnum8</dataType>
+                <alternative>
+                    <enumerator>Static</enumerator>
+                    <name>SpatialStatic</name>
+                    <dataType>SpatialStaticStruct</dataType>
+                    <semantics>Variant for representing a static object.</semantics>
+                </alternative>
+                <alternative>
+                    <enumerator>DRM_FPW</enumerator>
+                    <name>SpatialFPW</name>
+                    <dataType>SpatialFPStruct</dataType>
+                    <semantics>Variant for representing an object with a constant velocity (or low acceleration) linear motion in world coordinates.</semantics>
+                </alternative>
+                <alternative>
+                    <enumerator>DRM_RPW</enumerator>
+                    <name>SpatialRPW</name>
+                    <dataType>SpatialRPStruct</dataType>
+                    <semantics>Variant for representing an object with a constant velocity (or low acceleration) linear motion, including rotation information, in world coordinates.</semantics>
+                </alternative>
+                <alternative>
+                    <enumerator>DRM_RVW</enumerator>
+                    <name>SpatialRVW</name>
+                    <dataType>SpatialRVStruct</dataType>
+                    <semantics>Variant for representing an object with high speed or maneuvering at any speed, including rotation information, in world coordinates.</semantics>
+                </alternative>
+                <alternative>
+                    <enumerator>DRM_FVW</enumerator>
+                    <name>SpatialFVW</name>
+                    <dataType>SpatialFVStruct</dataType>
+                    <semantics>Variant for representing an object with high speed or maneuvering at any speed in world coordinates.</semantics>
+                </alternative>
+                <alternative>
+                    <enumerator>DRM_FPB</enumerator>
+                    <name>SpatialFPB</name>
+                    <dataType>SpatialFPStruct</dataType>
+                    <semantics>Variant for representing an object with a constant velocity (or low acceleration) linear motion in body axis coordinates.</semantics>
+                </alternative>
+                <alternative>
+                    <enumerator>DRM_RPB</enumerator>
+                    <name>SpatialRPB</name>
+                    <dataType>SpatialRPStruct</dataType>
+                    <semantics>Variant for representing an object with a constant velocity (or low acceleration) linear motion, including rotation information, in body axis coordinates.</semantics>
+                </alternative>
+                <alternative>
+                    <enumerator>DRM_RVB</enumerator>
+                    <name>SpatialRVB</name>
+                    <dataType>SpatialRVStruct</dataType>
+                    <semantics>Variant for representing an object with high speed or maneuvering at any speed, including rotation information, in body axis coordinates.</semantics>
+                </alternative>
+                <alternative>
+                    <enumerator>DRM_FVB</enumerator>
+                    <name>SpatialFVB</name>
+                    <dataType>SpatialFVStruct</dataType>
+                    <semantics>Variant for representing an object with high speed or maneuvering at any speed in body axis coordinates.</semantics>
+                </alternative>
+                <encoding>HLAvariantRecord</encoding>
+                <semantics>Variant Record for a single spatial attribute.</semantics>
+            </variantRecordData>
+            <variantRecordData notes="RPRnoteBase6">
+                <name>StationNameLocationVariantStruct</name>
+                <discriminant>StationName</discriminant>
+                <dataType>ConstituentPartStationNameEnum16</dataType>
+                <alternative>
+                    <enumerator>OnStationXYZ</enumerator>
+                    <name>RelativeLocation</name>
+                    <dataType>RelativePositionStruct</dataType>
+                    <semantics>The location of the constituent part object relative to the host object entity coordinate system.</semantics>
+                </alternative>
+                <alternative>
+                    <enumerator>OnStationRangeBearing</enumerator>
+                    <name>RelativeRangeAndBearing</name>
+                    <dataType>RelativeRangeBearingStruct</dataType>
+                    <semantics>The location of the constituent part object relative to the host object in polar coordinates.</semantics>
+                </alternative>
+                <encoding>HLAvariantRecord</encoding>
+                <semantics>The station name at which the constituent part is located. In case of 'On Station', the alternative specifies its location relative to the host object.</semantics>
+            </variantRecordData>
+        </variantRecordDataTypes>
+    </dataTypes>
+    <notes>
+        <note>
+            <label>RPRnoteBase1</label>
+            <semantics>Federates shall send the time at which the data is valid in the user defined tag with every attribute values update and interaction. The time shall be in the first 8 bytes (octets) of the user defined tag, using the DIS timestamp field format (see section 5.2.31 of IEEE 1278.1-1995) converted into hexadecimal ASCII character representation (0-9 and A-F). The ordering of the characters shall be in accordance with section 5.1.1 of IEEE 1278.1-1995, that is most significant octet first, with the most significant bits first (i.e. the character for bits 4-7 precedes the character for bits 0-3). 
+ 
+All federates shall transmit this field, even if they do not use it themselves, so that other federates can use its value to compensate for network transport delays.</semantics>
+        </note>
+        <note>
+            <label>RPRnoteBase2</label>
+            <semantics>Not optional</semantics>
+        </note>
+        <note>
+            <label>RPRnoteBase3</label>
+            <semantics>Default value: all zeros</semantics>
+        </note>
+        <note>
+            <label>RPRnoteBase4</label>
+            <semantics>This must reference a valid Object instance.</semantics>
+        </note>
+        <note>
+            <label>RPRnoteBase5</label>
+            <semantics>All fields in the entity type struct are enumerations. The values for the individual fields are to be derived from the federation agreements, which could refer to SISO-REF-010. The values used in this structure should comply with the requirements specified in section 5.2.16 of IEEE 1278.1-1995 (for platform and environmental entities) and section 5.2.39 of IEEE 1278.1a-1998 (for aggregate entities).</semantics>
+        </note>
+        <note>
+            <label>RPRnoteBase6</label>
+            <semantics>This note applies when this datatype is used within the BaseEntity.IsPartOf attribute. 
+The following StationName enumerations - On station RNG/BRG (15) and On station - x,y,z (16), are optional to transmit along with associated RelativeLocation or RelativeRangeAndBearing information. If these enumeration values (15) and (16) are received, they shall be ignored. The RelativeSpatial attribute shall be used in all cases. (Note: Although the RelativeLocation field uses the same WorldLocation contained in the RelativeSpatial attribute, in both these cases, the values do not represent a location in world coordinates, but, rather, the relative location of a part entity to the host entity in the referenced entity coordinate system. The RelativeRangeAndBearing field does not provide full relative spatial data and, therefore, cannot be substituted for the RelativeSpatial attribute.)</semantics>
+        </note>
+        <note>
+            <label>RPRnoteBase7</label>
+            <semantics>The units of the Value field depends on the value of the TypeMetric field. The units are defined in section A.2.1.4 of IEEE 1278.1-1995.</semantics>
+        </note>
+        <note>
+            <label>RPRnoteBase8</label>
+            <semantics>The TSPI_Change condition shall be evaluated as follows: The owner of a base entity object shall maintain two state models of the object in support of the dead reckoning process. One model shall be the internal model used by the simulation application to represent that object. The other shall be a dead reckoning model of the object. Certain thresholds shall be established as criteria for determining if the object's actual TSPI data has varied by an allowable amount from the dead reckoned TSPI data. TSPI_Change is TRUE when either: 
+a) the objects actual position differs from the dead reckoned position by more than DRA_POS_THRSH_DFLT 
+b) the objects actual orientation differs from the dead reckoned orientation by more than DRA_ORIENT_THRSH_DFLT 
+See section 5.1.4 of IEEE 1278.1-1995 for the value of these symbolic constants.</semantics>
+        </note>
+        <note>
+            <label>RPRnoteBase9</label>
+            <semantics>The values of the default update conditions are as follows: 
+DRA_POS_EPSILON_DFLT 0.001 m 
+DRA_ORIENT_EPSILON_DFLT 0.00001 rad 
+DRA_VEL_EPSILON_DFLT 0.001 m/s 
+DRA_ACCEL_EPSILON_DFLT 0.001 m/s/s 
+DRA_ANG_VEL_EPSILON_DFLT 0.00001 rad/s</semantics>
+        </note>
+        <note>
+            <label>RPRnoteBase10</label>
+            <semantics notes="RPRnoteBase8 RPRnoteBase9">The update condition for the WorldLocation field is TRUE when TSPI_Change is TRUE and the actual position differs from the last transmitted position by more than a threshold value in any direction. 
+The default threshold shall be DRA_POS_EPSILSON_DFLT.</semantics>
+        </note>
+        <note>
+            <label>RPRnoteBase11</label>
+            <semantics notes="RPRnoteBase8 RPRnoteBase9">The update condition for the Orientation field is TRUE when TSPI_Change is TRUE and the actual orientation differs from the last transmitted orientation by more than a threshold value in any orientation. 
+The default threshold shall be DRA_ORIENT_EPSILON_DFLT.</semantics>
+        </note>
+        <note>
+            <label>RPRnoteBase12</label>
+            <semantics notes="RPRnoteBase8 RPRnoteBase9">In case Dead Reckoning Algorithm FPW (2), RPW (3), RVW (4), FVW (5), FPB (6), RPB (7), RVB (8), or RVB (9) is used, the update condition for the VelocityVector field is TRUE when TSPI_Change is TRUE and the actual velocity differs from the last transmitted velocity by more than a threshold value in any direction. 
+The default threshold shall be DRA_VEL_EPSILON_DFLT.</semantics>
+        </note>
+        <note>
+            <label>RPRnoteBase13</label>
+            <semantics notes="RPRnoteBase8 RPRnoteBase9">In case Dead Reckoning Algorithm RVW (4), FVW (5), RVB (8), or RVB (9) is used, the update condition for the AccelerationVector field is TRUE when TSPI_Change is TRUE and the actual acceleration differs from the last transmitted acceleration by more than a threshold value in any direction. 
+The default threshold shall be DRA_ACCEL_EPSILON_DFLT.</semantics>
+        </note>
+        <note>
+            <label>RPRnoteBase14</label>
+            <semantics notes="RPRnoteBase8 RPRnoteBase9">In case Dead Reckoning Algorithm RPW (3), RVW (4), RPB (7), or RVB (8) is used, the update condition for the VelocityVector field is TRUE when TSPI_Change is TRUE and the actual angular velocity differs from the last transmitted angular velocity by more than a threshold value in any direction. 
+The default threshold shall be DRA_ANG_VEL_EPSILON_DFLT.</semantics>
+        </note>
+        <note>
+            <label>RPRnoteBase15</label>
+            <semantics>Frozen entities should not be dead-reckoned, i.e. should be displayed as fixed at the current location even if non-zero velocity, acceleration or rotation data received from the frozen entity.</semantics>
+        </note>
+        <note>
+            <label>RPRnoteBase16</label>
+            <semantics>The DatumLength equals the length in bits of the DatumValue only. The total size of a VariableDatumStruct record must account for the padding length.</semantics>
+        </note>
+        <note>
+            <label>RPRnoteBase17</label>
+            <semantics>The type of the DatumValue field is determined by the value of the DatumID field. The types and associated units, etc., for each of the DatumID enumeration values are to be derived from the federation agreements, which could refer to SISO-REF-010. The DatumValue element type is defined as a UnsignedInteger64 (64 bits) to ensure the correct byte alignment for types that include 64-bit elements.</semantics>
+        </note>
+        <note>
+            <label>RPRnoteBase18</label>
+            <semantics>If the entity is a constituent part of another entity (denoted by the IsPartOf attribute being set appropriately) then the Spatial attribute may be ignored by a receiving federate. Instead, the receiving federate can calculate spatial attribute values by adding the offsets provided in the RelativeSpatial attribute to the values provided in the host entity's Spatial attribute. Even if a federate is updating RelativeSpatial, it should still update Spatial for the benefit of federates who do not subscribe to the optional RelativeSpatial and IsPartOf attributes.</semantics>
+        </note>
+        <note>
+            <label>RPRnoteBase19</label>
+            <semantics>If the entity is a constituent part of another entity (denoted by the IsPartOf attribute being set appropriately) then the IsFrozen attribute is no longer updated. The frozen status of the entity is the same as the frozen status of the host entity.</semantics>
+        </note>
+        <note>
+            <label>RPRnoteBase20</label>
+            <semantics>Damaged appearance for environment objects has values 0: no damage, 1: damaged and 2: destroyed, with respect to the DIS standard as defined in SISO-REF-010 (section 12.1.2.1) ; this has to be taken into account when setting up a DIS-HLA gateway (SDEM mapping and filtering)</semantics>
+        </note>
+    </notes>
+</objectModel>

--- a/codebase/resources/testdata/hla/fomOverride/RPR-Physical_v2.0.xml
+++ b/codebase/resources/testdata/hla/fomOverride/RPR-Physical_v2.0.xml
@@ -1,0 +1,1038 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<objectModel xsi:schemaLocation="http://standards.ieee.org/IEEE1516-2010 http://standards.ieee.org/downloads/1516/1516.2-2010/IEEE1516-DIF-2010.xsd" xmlns="http://standards.ieee.org/IEEE1516-2010" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelIdentification>
+        <name>SISO-STD-001.1-2015 - Real-time Platform Reference Physical FOM Module</name>
+        <type>FOM</type>
+        <version>2.0</version>
+        <modificationDate>2015-08-10</modificationDate>
+        <securityClassification>Unclassified</securityClassification>
+        <purpose>The RPR FOM supports interoperability for real-time, platform oriented defense simulation.</purpose>
+        <applicationDomain>All domains</applicationDomain>
+        <description>This module provides object class definitions for representing physical entities including aircraft, ground vehicles, ships, life forms, ammunition, etc. In addition it provides interaction classes to signal collisions between physical entities.</description>
+        <useLimitation></useLimitation>
+        <poc>
+            <pocType>Primary author</pocType>
+            <pocName>RPR FOM Product Development Group</pocName>
+            <pocOrg>SISO - Simulation Interoperability Standards Organization</pocOrg>
+            <pocTelephone>+1 (407) 882-1348</pocTelephone>
+            <pocEmail>siso-help@sisostds.org</pocEmail>
+        </poc>
+        <reference>
+            <type>Dependency</type>
+            <identification>Real-time Platform Reference Base FOM Module</identification>
+        </reference>
+        <reference>
+            <type>Text Document</type>
+            <identification>Standard for Guidance, Rationale, and Interoperability Modalities for the Real-time Platform Reference Federation Object Model (RPR FOM)
+SISO-STD-001-2015
+10 August 2015</identification>
+        </reference>
+        <reference>
+            <type>Text Document</type>
+            <identification>IEEE Standard for Distributed Interactive Simulation - Application Protocols
+IEEE Std 1278.1-1995
+September 21, 1995</identification>
+        </reference>
+        <reference>
+            <type>Text Document</type>
+            <identification>IEEE Standard for Distributed Interactive Simulation - Application Protocols
+IEEE Std 1278.1a-1998
+19 March 1998</identification>
+        </reference>
+        <other>Copyright © 2015 by the Simulation Interoperability Standards Organization, Inc.
+P.O. Box 781238
+Orlando, FL 32878-1238, USA
+All rights reserved.
+
+Schema and API: SISO hereby grants a general, royalty-free license to copy, distribute, display, and make derivative works from this material, for all purposes, provided that any use of the material contains the following attribution: “Reprinted with permission from SISO Inc.” Should a reader require additional information, contact the SISO Inc. Board of Directors.
+
+Documentation: SISO hereby grants a general, royalty-free license to copy, distribute, display, and make derivative works from this material, for noncommercial purposes, provided that any use of the material contains the following attribution: “Reprinted with permission from SISO Inc.” The material may not be used for a commercial purpose without express written permission from the SISO Inc. Board of Directors.
+
+SISO Inc. Board of Directors
+P.O. Box 781238
+Orlando, FL 32878-1238, USA
+</other>
+        <glyph type="png" height="64" width="64" alt="">iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAABnJJREFUeNrsmktIVG0Yx0cdb6mZmqVmWeTdEE1BDBSSCOsjwmWCWxdtSiVCQSt0YYqISm0EL4i2UCgTLIh0kXRBCS1zoeb9FpVWKppWfr/mhcM0o9M5c0b9hm+exXDmPee8z/15/s87oz1y5IhGo7Gzs9NYG21sbPCp/fHjx/T0tMY66dChQ/aOjo4aqyWEt9dYOdkUsCnw9evXgoKC8PBwX19fSmJ/f7+i17W7K31vb29eXt6jR4/E17CwMFHWd0gBKrGaBvLq1ausrKwXL15IK6dOndq7d+/OhZBK6bOzs/Wlh+Lj460jB4T0z58/11/08vI6c+aM0q3MCaHBwcHXr19PTEx8/vx53759ERER0dHRNEVnZ2ezpYeioqKOHz+uWJqgoKAN2TQ8PJyZmRkQEKAfPPb29kh/9uzZpqamsbGxhYWFtbW1rXZ4+fIlgW4shoODQ1VV1YZCQngFHmhvb7969erQ0JBBDvz69WtaR52dnSEhIXFxcYTygQMHKIuo6uTkJFAXeo6Pj+fn5xvbHgoMDDx8+PD6+rpSaGOHEpjNxBPIh2R1dXXNzc3fv3+Xs6m7u7uLiwui8IlpJW2XlpZmZ2c3fQVVExISYmJiaAiRkZEnTpyQw+jo0aOmQgiDVVZWJicnY8XtTmsHHbm6upLKqKEqhDB5d3d3bW1tW1vbzMzMztSlnz9/8rmiI3FtThX6+PHj/fv36+vrUYBwtAos9IcCXV1dVBLSkdgV+eTm5ibyD/8CWigv2ycKgert7R0cHJyRkWFmEq/p6Nu3b5QagodYWl1dpSziU65HRkYmJydZ4euePXtYwd08TF5++vRJjBeQVqslX8Vdxj39KPfz8/Pw8OCWiGAeo3Xs378f/IPclC/6ib+/v5T3cpJYa2ADiBpCTTCGPTCGpVQThXpISTsbHR1FbtzF6+Ix2tytW7fevHkj7YB1CwsLaRf6OAp9YMdulgkh07DHwDB8ddMRpQMh5ufnKbIUyg8fPnAXH5JRBmmKnjQyTM7ziE6vUArd1HZiY0KmtLQ02hBiYWOQhauONg0DUguFEZoIJJyuXLlCXqnhrqwTb0okwPv37798+SIkxlFIyQUisqKPOOBHSuAHHx+fpKSk06dPp6Sk4AdLViEzKDExsa+vzzYT2xSwKWBTwKaATQGbArvTiQ0IZA44BaWavYOEwAU2AYCAtMHYO6EAcl+/fr2/v39ubk7CPwIgiSFBzlklg5RA2hIcTE1Nramp2fK0QiUa1acnT56IPYFrAjADORktPD09VZqmubl5u9CoPrW2tvKZkJBw7949Ox2J4wymtuLi4rq6OhS7cOECE480SABOHz58+NcjdV5nEtp8eLCUB4aHh728vNjw9u3bxndbWlq4df78eeNbqG06uoQhKisrN/WAxapQWVkZ0zPRIg5oRfQbnJqcPHnS4PxGHGmZHinZikm9urpaTN7bUkbfvXvX0NDABRUjNjZWY3TyThILb//BWyc3U6jQxDQRZo2NjaqqEGYQszwm4QKjigmLuoH5kYNnmDBv3ryJ9IuLi87OzrieWEd6spC7WJF8EGc2DHGsMIK2t7cbuGsrP9y9e/fSpUtM0srORnt6ejo6Orq6uiiOFJaVlRWGd/IJKZlol5eXkYlBXo4VVTUs7e/f5EtKSq5duyb3bBSqra0VM+6uE20Bd8XHx5MJcpOY8Oju7qY98TJqqDm9UU/iuOnt27dPnz6VmwOAAnG4y5skwHYHyV9zgFjFplNTUwoUkJ4W0oeGhqanp4uf4siNpqamwcFBywpqgoWoxYaBYCIHnj17FhgYyDPixy8qgPEzLFpQejksKioq9HPAlAKPHz8W3Rtgk5OTIxZv3Ljxj464ECvcsoj0MlmUlpbKVYB8x5u8k5SUJFYuX76sz5KvYh2/q48cmSzoM3IVgGgRwC9iievc3Fxjxixyq7y8XKUC7CCTheQWocDfG5lEUVFRAwMDBouRkZHgCHHX7B91wPrSJluxACyeO3eOPC4qKhJxoTH+fcA0iXPzrRbBm2bXWamwmGBx7NixBw8eoIDBv0EUKHDw4EEKq/GiuIiIiFCfxyZY0Ezxjyo0evHiRZmLZpM5LBQNNFuVCAuSIhaKR8o7d+74+vrSIDW6v8ZQ0SwOGZSyUFCF/oNEFbKdzNkU+N8rYC1/6tiUEJ5ZWfsbElnn3+8R/l8BBgBYyeAIZ9jsvgAAAABJRU5ErkJggg==</glyph>
+    </modelIdentification>
+    <objects>
+        <objectClass>
+            <name>HLAobjectRoot</name>
+            <objectClass>
+                <name>BaseEntity</name>
+                <objectClass>
+                    <name>PhysicalEntity</name>
+                    <sharing>Subscribe</sharing>
+                    <semantics>A base class of all discrete platform scenario domain participants.</semantics>
+                    <attribute notes="RPRnotePhysical2">
+                        <name>AcousticSignatureIndex</name>
+                        <dataType>Integer16</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>Index used to obtain the acoustics (sound through air) signature state of the entity.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical9">
+                        <name>AlternateEntityType</name>
+                        <dataType>EntityTypeStruct</dataType>
+                        <updateType>Static</updateType>
+                        <updateCondition>NA</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>The category of entity to be used when viewed by entities on the 'opposite' side.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical1">
+                        <name>ArticulatedParametersArray</name>
+                        <dataType>ArticulatedParameterStructLengthlessArray</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>Identification of the visible parts, and their states, of the entity which are capable of independent motion.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical7">
+                        <name>CamouflageType</name>
+                        <dataType>CamouflageEnum32</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>The type of camouflage in use (if any).</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical6">
+                        <name>DamageState</name>
+                        <dataType>DamageStatusEnum32</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>The state of damage of the entity.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical3">
+                        <name>EngineSmokeOn</name>
+                        <dataType>RPRboolean</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>Whether the entity's engine is generating smoke or not.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical3">
+                        <name>FirePowerDisabled</name>
+                        <dataType>RPRboolean</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>Whether the entity's main weapon system has been disabled or not.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical3">
+                        <name>FlamesPresent</name>
+                        <dataType>RPRboolean</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>Whether the entity is on fire (with visible flames) or not.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical4">
+                        <name>ForceIdentifier</name>
+                        <dataType>ForceIdentifierEnum8</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>The identification of the force that the entity belongs to.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical3">
+                        <name>HasAmmunitionSupplyCap</name>
+                        <dataType>RPRboolean</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>Whether the entity has the capability to supply other entities with ammunition.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical3">
+                        <name>HasFuelSupplyCap</name>
+                        <dataType>RPRboolean</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>Whether the entity has the capability to supply other entities with fuel or not.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical3">
+                        <name>HasRecoveryCap</name>
+                        <dataType>RPRboolean</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>Whether the entity has the capability to recover other entities or not.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical3">
+                        <name>HasRepairCap</name>
+                        <dataType>RPRboolean</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>Whether the entity has the capability to repair other entities or not.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical3">
+                        <name>Immobilized</name>
+                        <dataType>RPRboolean</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>Whether the entity is immobilized or not.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical2">
+                        <name>InfraredSignatureIndex</name>
+                        <dataType>Integer16</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>Index used to obtain the infra-red signature state of the entity.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical3">
+                        <name>IsConcealed</name>
+                        <dataType>RPRboolean</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>Whether the entity is concealed or not.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical2">
+                        <name>LiveEntityMeasuredSpeed</name>
+                        <dataType>VelocityDecimeterPerSecondInteger16</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>The entity's own measurement of speed (e.g. air speed for aircraft).</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical1">
+                        <name>Marking</name>
+                        <dataType>MarkingStruct</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>A unique marking or combination of characters used to distinguish the entity from other entities.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical3">
+                        <name>PowerPlantOn</name>
+                        <dataType>RPRboolean</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>Whether the entity's power plant is on or not.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical1">
+                        <name>PropulsionSystemsData</name>
+                        <dataType>PropulsionSystemDataStructLengthlessArray</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>The basic operating data of the propulsion systems aboard the entity.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical2">
+                        <name>RadarCrossSectionSignatureIndex</name>
+                        <dataType>Integer16</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>Index used to obtain the radar cross section signature state of the entity.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical3">
+                        <name>SmokePlumePresent</name>
+                        <dataType>RPRboolean</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>Whether the entity is generating smoke or not (intentional or unintentional).</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical3">
+                        <name>TentDeployed</name>
+                        <dataType>RPRboolean</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>Whether the entity has deployed tent or not.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical3">
+                        <name>TrailingEffectsCode</name>
+                        <dataType>TrailingEffectsCodeEnum32</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>The type and size of any trail that the entity is making.</semantics>
+                    </attribute>
+                    <attribute notes="RPRnotePhysical1">
+                        <name>VectoringNozzleSystemData</name>
+                        <dataType>VectoringNozzleSystemDataStructLengthlessArray</dataType>
+                        <updateType>Conditional</updateType>
+                        <updateCondition>On change</updateCondition>
+                        <ownership>DivestAcquire</ownership>
+                        <sharing>PublishSubscribe</sharing>
+                        <transportation>HLAbestEffort</transportation>
+                        <order>Receive</order>
+                        <semantics>The basic operational data for the vectoring nozzle systems aboard the entity.</semantics>
+                    </attribute>
+                    <objectClass>
+                        <name>Platform</name>
+                        <sharing>Subscribe</sharing>
+                        <semantics>A physical object under the control of armed forces upon which sensor, communication, or weapon systems may be mounted.</semantics>
+                        <attribute notes="RPRnotePhysical3 RPRnotePhysical10 RPRnotePhysical13">
+                            <name>AfterburnerOn</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the entity's afterburner is on or not.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical3 RPRnotePhysical10 RPRnotePhysical13">
+                            <name>AntiCollisionLightsOn</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the entity's anti-collision lights are on or not.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical3 RPRnotePhysical11 RPRnotePhysical12 RPRnotePhysical13">
+                            <name>BlackOutBrakeLightsOn</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the entity's black out brake lights are on or not.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical3 RPRnotePhysical11 RPRnotePhysical12 RPRnotePhysical13">
+                            <name>BlackOutLightsOn</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the entity's black out lights are on or not.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical3 RPRnotePhysical11 RPRnotePhysical12 RPRnotePhysical13">
+                            <name>BrakeLightsOn</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the entity's brake lights are on or not.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical3 RPRnotePhysical10 RPRnotePhysical13">
+                            <name>FormationLightsOn</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the entity's formation lights are on or not.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical5 RPRnotePhysical11 RPRnotePhysical12 RPRnotePhysical13 RPRnotePhysical14">
+                            <name>HatchState</name>
+                            <dataType>HatchStateEnum32</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>The state of the entity's (main) hatch.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical3 RPRnotePhysical11 RPRnotePhysical12 RPRnotePhysical13">
+                            <name>HeadLightsOn</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the entity's headlights are on or not.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical3 RPRnotePhysical10 RPRnotePhysical11 RPRnotePhysical12 RPRnotePhysical13 RPRnotePhysical15">
+                            <name>InteriorLightsOn</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the entity's internal lights are on or not.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical3 RPRnotePhysical10 RPRnotePhysical13">
+                            <name>LandingLightsOn</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the entity's landing lights are on or not.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical3 RPRnotePhysical13">
+                            <name>LauncherRaised</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the entity's weapon launcher is in the raised position.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical3 RPRnotePhysical10 RPRnotePhysical13">
+                            <name>NavigationLightsOn</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the entity's navigation lights are on or not.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical3 RPRnotePhysical13">
+                            <name>RampDeployed</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the entity has deployed a ramp or not.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical3 RPRnotePhysical11 RPRnotePhysical13 RPRnotePhysical14 RPRnotePhysical15">
+                            <name>RunningLightsOn</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the entity's running lights are on or not.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical3 RPRnotePhysical10 RPRnotePhysical11 RPRnotePhysical12 RPRnotePhysical13 RPRnotePhysical15">
+                            <name>SpotLightsOn</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the entity's spotlights are on or not.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical3 RPRnotePhysical11 RPRnotePhysical12 RPRnotePhysical13">
+                            <name>TailLightsOn</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the entity's tail lights are on or not.</semantics>
+                        </attribute>
+                        <objectClass>
+                            <name>Aircraft</name>
+                            <sharing>PublishSubscribe</sharing>
+                            <semantics>A platform entity that operates mainly in the air, such as aircraft, balloons, etc. This includes the entities when they are on the ground.</semantics>
+                        </objectClass>
+                        <objectClass>
+                            <name>AmphibiousVehicle</name>
+                            <sharing>PublishSubscribe</sharing>
+                            <semantics>A platform entity that can operate both on the land and the sea.</semantics>
+                        </objectClass>
+                        <objectClass>
+                            <name>GroundVehicle</name>
+                            <sharing>PublishSubscribe</sharing>
+                            <semantics>A platform entity that operates wholly on the surface of the earth.</semantics>
+                        </objectClass>
+                        <objectClass>
+                            <name>MultiDomainPlatform</name>
+                            <sharing>PublishSubscribe</sharing>
+                            <semantics>A platform entity that operates in more than one domain (excluding those combinations explicitly defined as subclasses of the superclass of this class).</semantics>
+                        </objectClass>
+                        <objectClass>
+                            <name>Spacecraft</name>
+                            <sharing>PublishSubscribe</sharing>
+                            <semantics>A platform entity that operates mainly in space.</semantics>
+                        </objectClass>
+                        <objectClass>
+                            <name>SubmersibleVessel</name>
+                            <sharing>PublishSubscribe</sharing>
+                            <semantics>A platform entity that operates either on the surface of the sea, or beneath it.</semantics>
+                        </objectClass>
+                        <objectClass>
+                            <name>SurfaceVessel</name>
+                            <sharing>PublishSubscribe</sharing>
+                            <semantics>A platform entity that operates wholly on the surface of the sea.</semantics>
+                        </objectClass>
+                    </objectClass>
+                    <objectClass>
+                        <name>Lifeform</name>
+                        <sharing>Subscribe</sharing>
+                        <semantics>A living military platform (human or not).</semantics>
+                        <attribute notes="RPRnotePhysical3">
+                            <name>FlashLightsOn</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the lifeform's flash lights are on or not.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical5">
+                            <name>StanceCode</name>
+                            <dataType>StanceCodeEnum32</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>The stance of the lifeform.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical8">
+                            <name>PrimaryWeaponState</name>
+                            <dataType>WeaponStateEnum32</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>The state of the soldier's primary weapon system.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical8">
+                            <name>SecondaryWeaponState</name>
+                            <dataType>WeaponStateEnum32</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>The state of the soldier's secondary weapon system.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical4">
+                            <name>ComplianceState</name>
+                            <dataType>ComplianceStateEnum32</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>The compliance of the lifeform.</semantics>
+                        </attribute>
+                        <objectClass>
+                            <name>Human</name>
+                            <sharing>PublishSubscribe</sharing>
+                            <semantics>A human lifeform.</semantics>
+                        </objectClass>
+                        <objectClass>
+                            <name>NonHuman</name>
+                            <sharing>PublishSubscribe</sharing>
+                            <semantics>An animal or other non-human lifeform.</semantics>
+                        </objectClass>
+                    </objectClass>
+                    <objectClass>
+                        <name>CulturalFeature</name>
+                        <sharing>PublishSubscribe</sharing>
+                        <semantics>Engineering and natural effects such as craters, bridges, vehicle tracks, etc.</semantics>
+                        <attribute notes="RPRnotePhysical3">
+                            <name>ExternalLightsOn</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the cultural feature's external lights are on or not.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical3">
+                            <name>InternalHeatSourceOn</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the cultural feature's internal heat source is on or not.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical3">
+                            <name>InternalLightsOn</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the cultural feature's internal lights are on or not.</semantics>
+                        </attribute>
+                    </objectClass>
+                    <objectClass>
+                        <name>Munition</name>
+                        <sharing>PublishSubscribe</sharing>
+                        <semantics>A complete device charged with explosives, propellants, pyrotechnics, initiating composition, or nuclear, biological or chemical material for use in military operations, including demolitions.</semantics>
+                        <attribute notes="RPRnotePhysical3">
+                            <name>LauncherFlashPresent</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the flash of the munition being launched is present or not.</semantics>
+                        </attribute>
+                    </objectClass>
+                    <objectClass>
+                        <name>Expendables</name>
+                        <sharing>PublishSubscribe</sharing>
+                        <semantics>Countermeasures devices that are dispensed from another entity. The devices may be active emitters or passive reflectors of energy.</semantics>
+                    </objectClass>
+                    <objectClass>
+                        <name>Radio</name>
+                        <sharing>PublishSubscribe</sharing>
+                        <semantics>Electronic devices for the communication of both audio and data, operated by entities belonging to armed forces.</semantics>
+                    </objectClass>
+                    <objectClass>
+                        <name>Sensor</name>
+                        <sharing>PublishSubscribe</sharing>
+                        <semantics>Sensors and emitters, such as stand-alone radars, jammers, and detection systems, that are not part of another platform or system described by another Physical Entity, and are operated by armed forces.</semantics>
+                        <attribute notes="RPRnotePhysical3">
+                            <name>AntennaRaised</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the sensor/emitter's antenna is raised or not.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical3">
+                            <name>BlackoutLightsOn</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the sensor/emitter's blackout lights are on or not.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical3">
+                            <name>LightsOn</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the sensor/emitter's lights are on or not.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical3">
+                            <name>InteriorLightsOn</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the sensor/emitter's interior lights are on or not.</semantics>
+                        </attribute>
+                        <attribute notes="RPRnotePhysical3">
+                            <name>MissionKill</name>
+                            <dataType>RPRboolean</dataType>
+                            <updateType>Conditional</updateType>
+                            <updateCondition>On change</updateCondition>
+                            <ownership>DivestAcquire</ownership>
+                            <sharing>PublishSubscribe</sharing>
+                            <transportation>HLAbestEffort</transportation>
+                            <order>Receive</order>
+                            <semantics>Whether the sensor/emitter has sustained damage that will prevent it carrying out its mission or not (e.g. damaged antenna).</semantics>
+                        </attribute>
+                    </objectClass>
+                    <objectClass>
+                        <name>Supplies</name>
+                        <sharing>PublishSubscribe</sharing>
+                        <semantics>Supplies other than munitions, such as fuel, food and personnel.</semantics>
+                    </objectClass>
+                </objectClass>
+            </objectClass>
+        </objectClass>
+    </objects>
+    <interactions>
+        <interactionClass>
+            <name>HLAinteractionRoot</name>
+            <interactionClass>
+                <name>Collision</name>
+                <sharing>PublishSubscribe</sharing>
+                <transportation>HLAbestEffort</transportation>
+                <order>Receive</order>
+                <semantics>The act or instance of coming together with solid impact.</semantics>
+                <parameter notes="RPRnotePhysical16">
+                    <name>CollidingObjectIdentifier</name>
+                    <dataType>RTIobjectId</dataType>
+                    <semantics>The object instance ID of the object that the issuing object has collided with.</semantics>
+                </parameter>
+                <parameter>
+                    <name>IssuingObjectMass</name>
+                    <dataType>MassKilogramFloat32</dataType>
+                    <semantics>The mass of the issuing object.</semantics>
+                </parameter>
+                <parameter>
+                    <name>IssuingObjectVelocityVector</name>
+                    <dataType>VelocityVectorStruct</dataType>
+                    <semantics>The velocity vector of the issuing object at the moment of impact.</semantics>
+                </parameter>
+                <parameter>
+                    <name>CollisionType</name>
+                    <dataType>CollisionTypeEnum8</dataType>
+                    <semantics>The type of collision.</semantics>
+                </parameter>
+                <parameter>
+                    <name>CollisionLocation</name>
+                    <dataType>RelativePositionStruct</dataType>
+                    <semantics>The location of the collision relative to the object that the issuing object has collided with.</semantics>
+                </parameter>
+                <parameter>
+                    <name>EventIdentifier</name>
+                    <dataType>EventIdentifierStruct</dataType>
+                    <semantics>An ID assigned by the issuing object to associate related collision events.</semantics>
+                </parameter>
+                <parameter notes="RPRnotePhysical17">
+                    <name>IssuingObjectIdentifier</name>
+                    <dataType>RTIobjectId</dataType>
+                    <semantics>The object instance ID of the object that has detected the collision and issued the collision interaction.</semantics>
+                </parameter>
+                <interactionClass>
+                    <name>CollisionElastic</name>
+                    <sharing>PublishSubscribe</sharing>
+                    <transportation>HLAbestEffort</transportation>
+                    <order>Receive</order>
+                    <semantics>The act or instance of coming together with solid impact in an elastic manner. An elastic collision allows a higher fidelity collision to be modeled, taking into account linear and rotational momentum transfer, variable elasticity, and momentum transfer that is dependent on surface orientation.</semantics>
+                    <parameter>
+                        <name>CoefficientOfRestitution</name>
+                        <dataType>Float32</dataType>
+                        <semantics>The degree that energy is conserved in a collision.</semantics>
+                    </parameter>
+                    <parameter>
+                        <name>IntermediateResultXX</name>
+                        <dataType>Float32</dataType>
+                        <semantics>X-X Component of the positive semi-definite Collision Intermediate Result matrix.</semantics>
+                    </parameter>
+                    <parameter>
+                        <name>IntermediateResultXY</name>
+                        <dataType>Float32</dataType>
+                        <semantics>X-Y Component of the positive semi-definite Collision Intermediate Result matrix.</semantics>
+                    </parameter>
+                    <parameter>
+                        <name>IntermediateResultXZ</name>
+                        <dataType>Float32</dataType>
+                        <semantics>X-Z Component of the positive semi-definite Collision Intermediate Result matrix.</semantics>
+                    </parameter>
+                    <parameter>
+                        <name>IntermediateResultYY</name>
+                        <dataType>Float32</dataType>
+                        <semantics>Y-Y Component of the positive semi-definite Collision Intermediate Result matrix.</semantics>
+                    </parameter>
+                    <parameter>
+                        <name>IntermediateResultYZ</name>
+                        <dataType>Float32</dataType>
+                        <semantics>Y-Z Component of the positive semi-definite Collision Intermediate Result matrix.</semantics>
+                    </parameter>
+                    <parameter>
+                        <name>IntermediateResultZZ</name>
+                        <dataType>Float32</dataType>
+                        <semantics>Z-Z Component of the positive semi-definite Collision Intermediate Result matrix.</semantics>
+                    </parameter>
+                    <parameter>
+                        <name>UnitSurfaceNormal</name>
+                        <dataType>EntityCoordinateVectorStruct</dataType>
+                        <semantics>The normal vector to the surface at the point of collision detection.</semantics>
+                    </parameter>
+                </interactionClass>
+            </interactionClass>
+        </interactionClass>
+    </interactions>
+    <dataTypes>
+        <simpleDataTypes>
+            <simpleData>
+                <name>RevolutionsPerMinuteFloat32</name>
+                <representation>HLAfloat32BE</representation>
+                <units>RPM</units>
+                <resolution>NA</resolution>
+                <accuracy>perfect</accuracy>
+                <semantics>Rotation speed expressed in revolutions per minute.</semantics>
+            </simpleData>
+            <simpleData>
+                <name>VelocityDecimeterPerSecondInteger16</name>
+                <representation>RPRunsignedInteger16BE</representation>
+                <units>decimeter per second (dm/s)</units>
+                <resolution>1</resolution>
+                <accuracy>perfect</accuracy>
+                <semantics>Velocity/Speed measured in decimeter per second.</semantics>
+            </simpleData>
+        </simpleDataTypes>
+        <arrayDataTypes>
+            <arrayData>
+                <name>MarkingArray11</name>
+                <dataType>Octet</dataType>
+                <cardinality>11</cardinality>
+                <encoding>HLAfixedArray</encoding>
+                <semantics>String of characters represented by an 11 element character string.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>PropulsionSystemDataStructLengthlessArray</name>
+                <dataType>PropulsionSystemDataStruct</dataType>
+                <cardinality>Dynamic</cardinality>
+                <encoding>RPRlengthlessArray</encoding>
+                <semantics>A set of Propulsion System Data descriptions.</semantics>
+            </arrayData>
+            <arrayData>
+                <name>VectoringNozzleSystemDataStructLengthlessArray</name>
+                <dataType>VectoringNozzleSystemDataStruct</dataType>
+                <cardinality>Dynamic</cardinality>
+                <encoding>RPRlengthlessArray</encoding>
+                <semantics>A set of Vectoring Nozzle System Data description.</semantics>
+            </arrayData>
+        </arrayDataTypes>
+        <fixedRecordDataTypes>
+            <fixedRecordData>
+                <name>EntityCoordinateVectorStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Vector in the entity coordinate system. Based on the Entity Coordinate Vector record as specified in IEEE 1278.1-1995 section 5.2.33a.</semantics>
+                <field>
+                    <name>XComponent</name>
+                    <dataType>MeterFloat32</dataType>
+                    <semantics>Component along the X axis</semantics>
+                </field>
+                <field>
+                    <name>YComponent</name>
+                    <dataType>MeterFloat32</dataType>
+                    <semantics>Component along the Y axis</semantics>
+                </field>
+                <field>
+                    <name>ZComponent</name>
+                    <dataType>MeterFloat32</dataType>
+                    <semantics>Component along the Z axis</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData notes="RPRnotePhysical18">
+                <name>MarkingStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Character set used in the marking and the string of characters to be interpreted for display.</semantics>
+                <field>
+                    <name>MarkingEncodingType</name>
+                    <dataType>MarkingEncodingEnum8</dataType>
+                    <semantics>Character set representation.</semantics>
+                </field>
+                <field>
+                    <name>MarkingData</name>
+                    <dataType>MarkingArray11</dataType>
+                    <semantics>11 element character string</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>PropulsionSystemDataStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Information describing a propulsion system in terms of power settings and current RPM.</semantics>
+                <field>
+                    <name>PowerSetting</name>
+                    <dataType>Float32</dataType>
+                    <semantics>The power setting of the propulsion system, after any response lags have been incorporated.</semantics>
+                </field>
+                <field>
+                    <name>EngineRPM</name>
+                    <dataType>RevolutionsPerMinuteFloat32</dataType>
+                    <semantics>The current engine speed.</semantics>
+                </field>
+            </fixedRecordData>
+            <fixedRecordData>
+                <name>VectoringNozzleSystemDataStruct</name>
+                <encoding>HLAfixedRecord</encoding>
+                <semantics>Operational data for describing the vectoring nozzle systems being simulated.</semantics>
+                <field>
+                    <name>HorizontalDeflectionAngle</name>
+                    <dataType>AngleDegreeFloat32</dataType>
+                    <semantics>The nozzle deflection angle in the horizontal body axis of the entity.</semantics>
+                </field>
+                <field>
+                    <name>VerticalDeflectionAngle</name>
+                    <dataType>AngleDegreeFloat32</dataType>
+                    <semantics>The nozzle deflection angle in the vertical body axis of the entity.</semantics>
+                </field>
+            </fixedRecordData>
+        </fixedRecordDataTypes>
+    </dataTypes>
+    <notes>
+        <note>
+            <label>RPRnotePhysical1</label>
+            <semantics>Default value: empty</semantics>
+        </note>
+        <note>
+            <label>RPRnotePhysical2</label>
+            <semantics>Default value: 0</semantics>
+        </note>
+        <note>
+            <label>RPRnotePhysical3</label>
+            <semantics>Default value: False</semantics>
+        </note>
+        <note>
+            <label>RPRnotePhysical4</label>
+            <semantics>Default value: Other</semantics>
+        </note>
+        <note>
+            <label>RPRnotePhysical5</label>
+            <semantics>Default value: NotApplicable</semantics>
+        </note>
+        <note>
+            <label>RPRnotePhysical6</label>
+            <semantics>Default value: NoDamage</semantics>
+        </note>
+        <note>
+            <label>RPRnotePhysical7</label>
+            <semantics>Default value: UniformPaintScheme</semantics>
+        </note>
+        <note>
+            <label>RPRnotePhysical8</label>
+            <semantics>Default value: NoWeapon</semantics>
+        </note>
+        <note>
+            <label>RPRnotePhysical9</label>
+            <semantics>Default value: BaseEntity.EntityType</semantics>
+        </note>
+        <note>
+            <label>RPRnotePhysical10</label>
+            <semantics>Applicable to Aircraft</semantics>
+        </note>
+        <note>
+            <label>RPRnotePhysical11</label>
+            <semantics>Applicable to AmphibiousVehicle</semantics>
+        </note>
+        <note>
+            <label>RPRnotePhysical12</label>
+            <semantics>Applicable to GroundVehicle</semantics>
+        </note>
+        <note>
+            <label>RPRnotePhysical13</label>
+            <semantics>Applicable to MultiDomainPlatform</semantics>
+        </note>
+        <note>
+            <label>RPRnotePhysical14</label>
+            <semantics>Applicable to SubmersibleVessel</semantics>
+        </note>
+        <note>
+            <label>RPRnotePhysical15</label>
+            <semantics>Applicable to SurfaceVessel</semantics>
+        </note>
+        <note>
+            <label>RPRnotePhysical16</label>
+            <semantics>If there is no object instance associated with the parameter, then this should be set to the empty string (no characters). Refer to SISO-STD-001 section 7.8.6 for handling empty strings.</semantics>
+        </note>
+        <note>
+            <label>RPRnotePhysical17</label>
+            <semantics>This must reference a valid object instance.</semantics>
+        </note>
+        <note>
+            <label>RPRnotePhysical18</label>
+            <semantics>The units and semantics for the MarkingData array elements are specified by the value of the MarkingEncodingType.</semantics>
+        </note>
+    </notes>
+</objectModel>

--- a/codebase/resources/testdata/hla/fomOverride/RPR-Switches_v2.0.xml
+++ b/codebase/resources/testdata/hla/fomOverride/RPR-Switches_v2.0.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<objectModel xsi:schemaLocation="http://standards.ieee.org/IEEE1516-2010 http://standards.ieee.org/downloads/1516/1516.2-2010/IEEE1516-DIF-2010.xsd" xmlns="http://standards.ieee.org/IEEE1516-2010" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelIdentification>
+        <name>SISO-STD-001.1-2015 - Real-time Platform Reference Switches FOM Module</name>
+        <type>FOM</type>
+        <version>2.0</version>
+        <modificationDate>2015-08-10</modificationDate>
+        <securityClassification>Unclassified</securityClassification>
+        <purpose>The RPR FOM supports interoperability for real-time, platform oriented defense simulation.</purpose>
+        <applicationDomain>All domains</applicationDomain>
+        <description>This module contains the switches, required by the HLA standard to be part of a complete FOM.</description>
+        <useLimitation></useLimitation>
+        <poc>
+            <pocType>Primary author</pocType>
+            <pocName>RPR FOM Product Development Group</pocName>
+            <pocOrg>SISO - Simulation Interoperability Standards Organization</pocOrg>
+            <pocTelephone>+1 (407) 882-1348</pocTelephone>
+            <pocEmail>siso-help@sisostds.org</pocEmail>
+        </poc>
+        <reference>
+            <type>Dependency</type>
+            <identification>MIM</identification>
+        </reference>
+        <reference>
+            <type>Text Document</type>
+            <identification>Standard for Guidance, Rationale, and Interoperability Modalities for the Real-time Platform Reference Federation Object Model (RPR FOM)
+SISO-STD-001-2015
+10 August 2015</identification>
+        </reference>
+        <reference>
+            <type>Text Document</type>
+            <identification>IEEE Standard for Distributed Interactive Simulation - Application Protocols
+IEEE Std 1278.1-1995
+September 21, 1995</identification>
+        </reference>
+        <reference>
+            <type>Text Document</type>
+            <identification>IEEE Standard for Distributed Interactive Simulation - Application Protocols
+IEEE Std 1278.1a-1998
+19 March 1998</identification>
+        </reference>
+        <other>Copyright © 2015 by the Simulation Interoperability Standards Organization, Inc.
+P.O. Box 781238
+Orlando, FL 32878-1238, USA
+All rights reserved.
+
+Schema and API: SISO hereby grants a general, royalty-free license to copy, distribute, display, and make derivative works from this material, for all purposes, provided that any use of the material contains the following attribution: “Reprinted with permission from SISO Inc.” Should a reader require additional information, contact the SISO Inc. Board of Directors.
+
+Documentation: SISO hereby grants a general, royalty-free license to copy, distribute, display, and make derivative works from this material, for noncommercial purposes, provided that any use of the material contains the following attribution: “Reprinted with permission from SISO Inc.” The material may not be used for a commercial purpose without express written permission from the SISO Inc. Board of Directors.
+
+SISO Inc. Board of Directors
+P.O. Box 781238
+Orlando, FL 32878-1238, USA
+</other>
+        <glyph type="png" height="64" width="64" alt="">iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAABVZJREFUeNrsWksvc10ULq26fwMkCIqIKirqm2DgkqAY6ECEgUSExsxfEE0kEmrATEQ6MNEBFZGoWxgSjdSlLpEgEdcg4k5d3ufrSZqmn7NPTy/7fZvXSpxs3bu7+zlnr7WeZ+0TIJFIBAJBQECAwN/s6+sLV9H7+/vJyYnAPy0hISEwKChI4LeGxQcK/Nx+APwA8NBErgza2toyGAyrq6v39/c0bmpgYHJyslKprKmpCQ8P5xiNoV9E0+v1CoWC/q0NCwtTq9XHx8eEtWHxAfg7Ojpim6Wzs1Oj0VBYrlwuLykpiYmJQfvq6mpxcXF7exttmUw2OTmZnp7+7bdSUlJIT2B0dJROLO/t7X1+fnb86cfHx56eHiZH5efn41+2J8AKwGw2S6VSCgD6+vrY7qBWq2XGDA4O8gbQ0dFBYfXwLnAZNgBWqzU3NxfDysvL2QCwhtG1tTUKAEpLS4VCIWuIFInKysrQYPyBXx7AtqMAICIigjwgMjIS16enJ94AkpKSKADY29sjD7BYLLjGx8fzBlBRUSEWi30NwGg07uzssPWia2ZmBo2ioiLeiez29raxsZHCQygsLDw9Pf3/AqBS0MXEWZAA3lEIhiyYlpZGAUNmZubw8PDBwcGtzdAYGhpCCmN6u7q6CJmYg0rgISKP0OEO2LERNrNv3eDg4O7ubo+oBBMBdDrd+Pj45ubmy8vLt9rUQ0n9+fmJST4+Pph/EVjhtYiw4EIFBQWEL4JKcAOwrxJUFAAYKe34OX4eAdvpc172+vrq+C8YKJhcaGgo5xcBQOTib+Ae/2OzH0HzOwQNeWth72ILeTKJk2uFhIR4GYDJZJqYmAAhubu7c/JXUDEwYWwtt30ALnR+fo55GFfG/CABqampkAe1tbWcXIMjjIIRtbe306kdQUmG2MxR5UDZkMMoCQACKFQphaUjZyFz7e/vM4kMDQgARo0gHEGRuQPg7e0NepIOlQBrIFCJuLg4NmVMAjA7OxsdHe3r1cN5dnd32W4wqChDp6GueAsaPLjr62tfA6isrMzIyGDrzcrKqq6uRmN6epp3HuBk6l4xwurtPA/Xw8PDPzSRPTw8kAcgcLuZiTnvjVcMURIZgK0XXQsLC2ggLfAGoFKpKDjx+vp6f38/W+/AwMDGxgYajCfwS2TUwiiypFardSpsIQXZC1vkMEqi05i0vr5+amqKAoycnBwIgKioKLRvbm6WlpYgP9AGqdbr9Wz5lKO0yGgAUAkoo9/i4gqFYm5uzlNFxhS5oMh8SuZwtQuPxMREiURSXFxcV1cHKuEFQfOvzfyYTpOVmoer57viv1iRwQHYNvq7zTxfDZ4n5hGLxdD1roh6lwDAR3U63djYmNlstpcPAm3m6AmeVCWcnAozx8bGQpG1traSyyrcisypsIW74vq98dxcKWy5WlpsaWlBcrm4uIBiwhXt5uZmOjDcLC3ai7tCoZDthAefE44nvMg1TCYTbwAjIyNMjbKtrY3wENVqNYWHwLYGEoCmpiaB7ZBnZWWFAAC9nucBV8rXvCUlHIApCpAr7FKplPsw3WM7OzvjnciYZSEqk0UT2J7VavU1AELcYwWQl5cnsNXWEXAIU8/PzxNO4Lxl2dnZvPOA/aBbJpNdXl5+OwafM6Lb1+bOQbfjqwZIh8Dj1AuOTefwhvyqASmANDQ0IBNrNJrl5WVgqKqqksvlCPzgzxaLxWg0gmVQqDoioJNUgSuv2zDn/ZTNxddtuEM4ZDE2usFgQDqk9sITFJlSqVSpVJwx2qUclGOzP1MP/Lz09wPgrwdAgcn4zrB4cGHRf/Ut/3z9Hov/JcAAoOtCtVEJU98AAAAASUVORK5CYII=</glyph>
+    </modelIdentification>
+    <switches>
+        <autoProvide isEnabled="true"/>
+        <conveyRegionDesignatorSets isEnabled="false"/>
+        <conveyProducingFederate isEnabled="false"/>
+        <attributeScopeAdvisory isEnabled="false"/>
+        <attributeRelevanceAdvisory isEnabled="false"/>
+        <objectClassRelevanceAdvisory isEnabled="false"/>
+        <interactionRelevanceAdvisory isEnabled="false"/>
+        <serviceReporting isEnabled="false"/>
+        <exceptionReporting isEnabled="false"/>
+        <delaySubscriptionEvaluation isEnabled="false"/>
+        <automaticResignAction resignAction="CancelThenDeleteThenDivest"/>
+    </switches>
+</objectModel>

--- a/codebase/src/java/test/org/openlvc/disco/rpr/RprFomLifecycleTest.java
+++ b/codebase/src/java/test/org/openlvc/disco/rpr/RprFomLifecycleTest.java
@@ -1,0 +1,120 @@
+/*
+ *   Copyright 2025 Open LVC Project.
+ *
+ *   This file is part of Open LVC Disco.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package org.openlvc.disco.rpr;
+
+import java.io.File;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.openlvc.disco.AbstractTest;
+import org.openlvc.disco.common.CommonSetup;
+import org.openlvc.disco.configuration.DiscoConfiguration;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+@Test(groups={"hla","rpr"})
+public class RprFomLifecycleTest extends AbstractTest
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	///////////////////////////////////////////////////////////////////////////////////
+	/// Test Class Setup/Tear Down   //////////////////////////////////////////////////
+	///////////////////////////////////////////////////////////////////////////////////
+	@BeforeClass(alwaysRun=true)
+	public void beforeClass()
+	{
+		// NOTE: Portico Specific Code
+		// if we are using Portico, we can control the log level through system properties
+		System.setProperty( "portico.loglevel", CommonSetup.CONSOLE_LOG_LEVEL );
+		System.setProperty( "portico.connection", "jvm" );
+	}
+	
+	@BeforeMethod(alwaysRun=true)
+	public void beforeMethod()
+	{
+	}
+
+	@AfterMethod(alwaysRun=true)
+	public void afterMethod()
+	{
+	}
+	
+	@AfterClass(alwaysRun=true)
+	public void afterClass()
+	{
+	}
+
+	///////////////////////////////////////////////////////////////////////////////////
+	/// RPR FOM Testing Methods   /////////////////////////////////////////////////////
+	///////////////////////////////////////////////////////////////////////////////////
+	@Test
+	public void testRprLoadFomOverrideDirectory()
+	{
+		DiscoConfiguration config = new DiscoConfiguration();
+		config.setConnection( "rpr" );
+		config.getRprConfiguration().setFomOverridePath( "resources/testdata/hla/fomOverride" );
+		// Also add a custom extension, to make sure they can be used with overrides path
+		config.getRprConfiguration().registerExtensionModules( "resources/testdata/hla/Custom-FOM-Module.xml" );
+		
+		// Create Opscenter with configuration
+		// We probably don't need to do this, but should we? It will help confirm that the
+		// modules flow through to the actualy running Disco
+		//OpsCenter opsCenter = new OpsCenter( config );
+		//opsCenter.open();
+		//opsCenter.close();
+		
+		// Check that the FOM modules are loaded
+		URL[] modules = config.getRprConfiguration().getRegisteredFomModules();
+		Assert.assertEquals( modules.length, 5 );
+		
+		// Check the names of the modules
+		Set<String> expectedNames = new HashSet<>();
+		expectedNames.add( "HLAstandardMIM.xml" );
+		expectedNames.add( "RPR-Base_v2.0.xml" );
+		expectedNames.add( "RPR-Physical_v2.0.xml" );
+		expectedNames.add( "RPR-Switches_v2.0.xml" );
+		expectedNames.add( "Custom-FOM-Module.xml" );
+		Set<String> actualNames = new HashSet<>();
+		for( URL module : modules )
+			actualNames.add( new File(module.getPath()).getName() );
+		Assert.assertEquals( actualNames, expectedNames );
+	}
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}


### PR DESCRIPTION
This adds support to the RPR configuration for specifying a directory that can be used to load modules from in place of the default modules used inside the JAR file.

It is important to note that if you use this option, you will need to specify/provide _all_ of the RPR modules, as the defaults will not be used. This does however allow you to change the content of the modules.

Any .xml files inside the specified override directory will be treated as modules and loaded.

Fix: #83