### PR TITLE
Fix emitter beams not clearing

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/application/EmitterStore.java
+++ b/codebase/src/java/disco/org/openlvc/disco/application/EmitterStore.java
@@ -104,7 +104,7 @@ public class EmitterStore implements IDeleteReaperManaged
 
 			// Remove any Beams we have first.
 			// If the pdu does not contain any, they should be deleted...
-			existing.getBeams().clear();
+			existing.clearBeams();
 			
 			// Update the beams - either adding them or replacing them
 			for( EmitterBeam beam : incoming.getBeams() )

--- a/codebase/src/java/disco/org/openlvc/disco/pdu/emissions/EmitterSystem.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/emissions/EmitterSystem.java
@@ -251,6 +251,11 @@ public class EmitterSystem implements IPduComponent, Cloneable
 		return new HashSet<>( beams.values() );
 	}
 
+	public void clearBeams()
+	{
+		beams.values().clear();
+	}
+
 	/**
 	 * Put the given Beam into this system, returning the object that is already stored
 	 * for the beam number, or null if we don't have one for this number yet.


### PR DESCRIPTION
Stored emitter beams were meant to be reset every time a new packet is received, but an erroneous call was preventing this. This makes the emitter beam reset as intended.

Note: After this change DIS v5/6 Complete-Entity and Complete-System issuance methods will work correctly, but the DIS v7 Complete-Beam issuance method (still) won't properly be supported. See also #91.