### PR TITLE
DIS v7 support for Electromagnetic Emission PDUs ('Complete-Beam' issuance, 'Beam State')

### DIFF
--- a/codebase/src/java/disco/org/openlvc/disco/connection/rpr/mappers/EmitterSystemMapper.java
+++ b/codebase/src/java/disco/org/openlvc/disco/connection/rpr/mappers/EmitterSystemMapper.java
@@ -30,6 +30,7 @@ import org.openlvc.disco.connection.rpr.types.array.RTIobjectId;
 import org.openlvc.disco.pdu.emissions.EmissionPdu;
 import org.openlvc.disco.pdu.emissions.EmitterSystem;
 import org.openlvc.disco.pdu.field.PduType;
+import org.openlvc.disco.pdu.field.ProtocolVersion;
 
 import hla.rti1516e.AttributeHandleValueMap;
 
@@ -218,6 +219,8 @@ public class EmitterSystemMapper extends AbstractEmitterMapper
 		// FIXME - We serialize it to a byte[], but it will be turned back into a PDU
 		//         on the other side. This is inefficient and distasteful. Fix me.
 		EmissionPdu pdu = super.toPdu( rprSystem, rprBeams );
+		// explicitly set the packet as v6, because we disable beams by removing them rather than using v7's 'Beam Status'
+		pdu.getHeader().setVersion( ProtocolVersion.Version6 );
 		opscenter.getPduReceiver().receive( pdu.toByteArray() );
 	}
 

--- a/codebase/src/java/disco/org/openlvc/disco/pdu/emissions/EmitterSystem.java
+++ b/codebase/src/java/disco/org/openlvc/disco/pdu/emissions/EmitterSystem.java
@@ -217,6 +217,17 @@ public class EmitterSystem implements IPduComponent, Cloneable
 		
 		return (short)dataLength;
 	}
+
+	/**
+	 * Returns if the Complete-System emitter system represented by this PDU is active (if the
+	 * system contains any active beams).
+	 * 
+	 * @return true iff the system contains an active beam
+	 */
+	public boolean isSystemActive()
+	{
+		return this.getBeams().parallelStream().anyMatch( beam -> beam.isBeamActive() );
+	}
 	
 	////////////////////////////////////////////////////////////////////////////////////////////
 	/// Accessor and Mutator Methods   /////////////////////////////////////////////////////////


### PR DESCRIPTION
Adds support for receiving DIS v7 Complete-Beam EE PDUs to `EmitterStore` (while maintaining support for v7 Complete-System, Complete-Entity, and all v6 PDUs) and updates HLA -> DIS handling to properly produce v7 EE PDUs with disabled beams announced as disabled rather than missing.

- [x] `EmitterStore` update
- [x] HLA -> DIS update

Resolves: #91