### PR TITLE
Fix FOM extension loading under MAK

### DIFF
--- a/codebase/build.properties
+++ b/codebase/build.properties
@@ -23,7 +23,7 @@
 build.longname = Open LVC Disco
 build.shortname = disco
 build.version = 1.2.0
-build.number = 6
+build.number = 7
 
 #################################
 # Java Development Kit Settings #

--- a/codebase/src/java/disco/org/openlvc/disco/configuration/RprConfiguration.java
+++ b/codebase/src/java/disco/org/openlvc/disco/configuration/RprConfiguration.java
@@ -509,7 +509,7 @@ public class RprConfiguration
 			else if( getRtiProvider() == RtiProvider.Mak )
 			{
 				// if we're using Mak and it's not an external module, copy stuff out
-				createMakFomFiles( new String[]{path}, new File("hla/mak") );
+				fomModules.addAll( createMakFomFiles(new String[]{path}, new File("hla/mak")) );
 			}
 			else
 			{


### PR DESCRIPTION
Currently, extension modules are ignored after being copied out of the jar when loading under MAK.

This PR simply adds them to the `fomModules` alongside the others.